### PR TITLE
SEO: structured data, meta fixes, custom sitemap, demo OG image fix

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 import react from "@astrojs/react";
 import remarkToc from "remark-toc";
-import sitemap from "@astrojs/sitemap";
 import { SITE } from "./src/config";
 import risoAnalogTheme, {
   risoAnalogSyntaxTransformer,
@@ -19,7 +18,6 @@ export default defineConfig({
       applyBaseStyles: false,
     }),
     react(),
-    sitemap(),
     mdx(),
   ],
   markdown: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@fontsource/lora": "^5.2.5",
         "@fontsource/zilla-slab": "^5.2.5",
         "@headlessui/react": "^2.1.1",
-        "@headlessui/tailwindcss": "0.2.1",
         "@heroicons/react": "^2.2.0",
         "@resvg/resvg-js": "^2.6.0",
         "astro": "^4.16.3",
@@ -32,7 +31,6 @@
       },
       "devDependencies": {
         "@astrojs/react": "^3.6.2",
-        "@astrojs/sitemap": "3.1.6",
         "@astrojs/tailwind": "^5.1.1",
         "@tailwindcss/forms": "0.5.7",
         "@tailwindcss/typography": "^0.5.15",
@@ -577,18 +575,6 @@
       "dependencies": {
         "fast-xml-parser": "^4.4.0",
         "kleur": "^4.1.5"
-      }
-    },
-    "node_modules/@astrojs/sitemap": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.1.6.tgz",
-      "integrity": "sha512-1Qp2NvAzVImqA6y+LubKi1DVhve/hXXgFvB0szxiipzh7BvtuKe4oJJ9dXSqaubaTkt4nMa6dv6RCCAYeB6xaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sitemap": "^7.1.2",
-        "stream-replace-string": "^2.0.0",
-        "zod": "^3.23.8"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -2598,18 +2584,6 @@
       "peerDependencies": {
         "react": "^18",
         "react-dom": "^18"
-      }
-    },
-    "node_modules/@headlessui/tailwindcss": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.2.1.tgz",
-      "integrity": "sha512-2+5+NZ+RzMyrVeCZOxdbvkUSssSxGvcUxphkIfSVLpRiKsj+/63T2TOL9dBYMXVfj/CGr6hMxSRInzXv6YY7sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "tailwindcss": "^3.0"
       }
     },
     "node_modules/@heroicons/react": {
@@ -6553,16 +6527,6 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
-      }
-    },
-    "node_modules/@types/sax": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
-      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/tern": {
@@ -24442,13 +24406,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -24930,33 +24887,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
-    "node_modules/sitemap": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
-      "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^17.0.5",
-        "@types/sax": "^1.2.1",
-        "arg": "^5.0.0",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "sitemap": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=5.6.0"
-      }
-    },
-    "node_modules/sitemap/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/slate": {
       "version": "0.94.1",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.94.1.tgz",
@@ -25201,13 +25131,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/stopword/-/stopword-2.0.8.tgz",
       "integrity": "sha512-btlEC2vEuhCuvshz99hSGsY8GzaP5qzDPQm56j6rR/R38p8xdsOXgU5a6tIgvU/4hcCta1Vlo/2FVXA9m0f8XA==",
-      "license": "MIT"
-    },
-    "node_modules/stream-replace-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
-      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/streamroller": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@fontsource/lora": "^5.2.5",
     "@fontsource/zilla-slab": "^5.2.5",
     "@headlessui/react": "^2.1.1",
-    "@headlessui/tailwindcss": "0.2.1",
     "@heroicons/react": "^2.2.0",
     "@resvg/resvg-js": "^2.6.0",
     "astro": "^4.16.3",
@@ -42,7 +41,6 @@
   },
   "devDependencies": {
     "@astrojs/react": "^3.6.2",
-    "@astrojs/sitemap": "3.1.6",
     "@astrojs/tailwind": "^5.1.1",
     "@tailwindcss/forms": "0.5.7",
     "@tailwindcss/typography": "^0.5.15",

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "",
-  "short_name": "",
+  "name": "Rachel Cantor",
+  "short_name": "rachel.fyi",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",

--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -1,12 +1,7 @@
 ---
-export interface Props {
-  /** Optional because the disabled state renders a <span> without a link. */
-  href?: string;
-  className?: string;
-  ariaLabel?: string;
-  title?: string;
-  disabled?: boolean;
-}
+import type { LinkButtonProps } from "../types";
+
+export type Props = LinkButtonProps;
 
 const { href, className, ariaLabel, title, disabled = false } = Astro.props;
 ---

--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -1,6 +1,7 @@
 ---
 export interface Props {
-  href: string;
+  /** Optional because the disabled state renders a <span> without a link. */
+  href?: string;
   className?: string;
   ariaLabel?: string;
   title?: string;

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -19,14 +19,16 @@ function stripTrailingSlash(url: string | undefined): string | undefined {
 
 const prevUrl = stripTrailingSlash(page.url.prev as string | undefined);
 const nextUrl = stripTrailingSlash(page.url.next as string | undefined);
+
+const prevProps = prevUrl ? { href: prevUrl } : { disabled: true as const };
+const nextProps = nextUrl ? { href: nextUrl } : { disabled: true as const };
 ---
 
 {
   page.lastPage > 1 && (
     <nav class="pagination-wrapper" aria-label="Pagination">
       <LinkButton
-        disabled={!prevUrl}
-        href={prevUrl}
+        {...prevProps}
         className={`mr-4 select-none flex items-center gap-1 ${prevUrl ? "" : "disabled"}`}
         ariaLabel="Previous"
       >
@@ -43,8 +45,7 @@ const nextUrl = stripTrailingSlash(page.url.next as string | undefined);
         {page.currentPage} / {page.lastPage}
       </span>
       <LinkButton
-        disabled={!nextUrl}
-        href={nextUrl}
+        {...nextProps}
         className={`mx-4 select-none flex items-center gap-1 ${nextUrl ? "" : "disabled"}`}
         ariaLabel="Next"
       >

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export const SITE: Site = {
 
 export const LOCALE = {
   lang: "en", // html lang code. Set this empty and default will be "en"
-  langTag: ["en-EN"], // BCP 47 Language Tags. Set this empty [] to use the environment default
+  langTag: ["en-US"], // BCP 47 Language Tags. Set this empty [] to use the environment default
 } as const;
 
 export const LOGO_IMAGE = {

--- a/src/layouts/DemoDetails.astro
+++ b/src/layouts/DemoDetails.astro
@@ -46,6 +46,7 @@ const layoutProps = {
   ogImage: ogUrl,
   ogImageAlt: title,
   pageType: "article" as const,
+  breadcrumbName: title,
   structuredData: [
     creativeWorkSchema({
       title,

--- a/src/layouts/DemoDetails.astro
+++ b/src/layouts/DemoDetails.astro
@@ -6,6 +6,7 @@ import GhostEntryBack from "@components/riso/GhostEntryBack";
 import PostPagination from "@components/riso/PostPagination";
 import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
+import { creativeWorkSchema } from "@utils/structuredData";
 import { SITE } from "@config";
 export interface Props {
   demo: CollectionEntry<"demos">;
@@ -33,6 +34,8 @@ const ogUrl = new URL(
   Astro.url.origin
 ).href;
 
+const pageUrl = canonicalURL ?? new URL(Astro.url.pathname, SITE.website).href;
+
 const layoutProps = {
   title: `${title} | ${SITE.title}`,
   author,
@@ -41,6 +44,19 @@ const layoutProps = {
   modDatetime,
   canonicalURL,
   ogImage: ogUrl,
+  ogImageAlt: title,
+  pageType: "article" as const,
+  structuredData: [
+    creativeWorkSchema({
+      title,
+      description: description ?? summary,
+      url: pageUrl,
+      image: ogUrl,
+      author,
+      pubDatetime,
+      modDatetime,
+    }),
+  ],
 };
 
 const allDemos = demos.map(({ data: { title: t }, slug }) => ({

--- a/src/layouts/DemoDetails.astro
+++ b/src/layouts/DemoDetails.astro
@@ -7,6 +7,8 @@ import PostPagination from "@components/riso/PostPagination";
 import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import { creativeWorkSchema } from "@utils/structuredData";
+import { getCanonicalURL } from "@utils/canonicalURL";
+import { resolveOgImage } from "@utils/ogImage";
 import { SITE } from "@config";
 export interface Props {
   demo: CollectionEntry<"demos">;
@@ -28,22 +30,24 @@ const {
 
 const { Content } = await demo.render();
 
-const ogImageUrl = typeof ogImage === "string" ? ogImage : ogImage?.src;
-const ogUrl = new URL(
-  ogImageUrl ?? `/demos/${slugifyStr(title)}.png`,
+const og = resolveOgImage(
+  ogImage,
+  `/demos/${slugifyStr(title)}.png`,
   Astro.url.origin
-).href;
+);
 
-const pageUrl = canonicalURL ?? new URL(Astro.url.pathname, SITE.website).href;
+const pageUrl = canonicalURL ?? getCanonicalURL(Astro.url.pathname);
 
 const layoutProps = {
   title: `${title} | ${SITE.title}`,
   author,
-  description,
+  description: description ?? summary,
   pubDatetime,
   modDatetime,
   canonicalURL,
-  ogImage: ogUrl,
+  ogImage: og.url,
+  ogImageWidth: og.width,
+  ogImageHeight: og.height,
   ogImageAlt: title,
   pageType: "article" as const,
   breadcrumbName: title,
@@ -52,7 +56,7 @@ const layoutProps = {
       title,
       description: description ?? summary,
       url: pageUrl,
-      image: ogUrl,
+      image: og.url,
       author,
       pubDatetime,
       modDatetime,

--- a/src/layouts/Demos.astro
+++ b/src/layouts/Demos.astro
@@ -12,9 +12,14 @@ export interface Props {
 }
 
 const { page } = Astro.props;
+
+const pageSuffix = page.currentPage > 1 ? ` (page ${page.currentPage})` : "";
 ---
 
-<Layout title={`Demos | ${SITE.title}`}>
+<Layout
+  title={`Demos${pageSuffix} | ${SITE.title}`}
+  description={`Interactive UI demos by ${SITE.author} — accessible patterns built with React.`}
+>
   <Main pageTitle="Demos" showBreadcrumbs={false}>
     <ul class="list-none pl-0">
       {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,18 +18,23 @@ import "@fontsource/ibm-plex-mono/700.css";
 import "@fontsource/ibm-plex-mono/400-italic.css";
 
 import { ViewTransitions } from "astro:transitions";
+import { getBreadcrumbItems } from "@utils/breadcrumbItems";
+import { breadcrumbSchema } from "@utils/structuredData";
 
 const googleSiteVerification = import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION;
 
 export interface Props {
   title?: string;
   author?: string;
-  profile?: string;
   description?: string;
   ogImage?: string;
+  ogImageAlt?: string;
   canonicalURL?: string;
   pubDatetime?: Date;
   modDatetime?: Date | null;
+  pageType?: "website" | "article";
+  structuredData?: Record<string, unknown>[];
+  noindex?: boolean;
 }
 
 /** Ensure canonical URL has no trailing slash for directory-like pages (SEO consistency) */
@@ -46,45 +51,39 @@ function getCanonicalURL(): string {
 const {
   title = SITE.title,
   author = SITE.author,
-  profile = SITE.profile,
   description = SITE.desc,
   ogImage = SITE.ogImage,
+  ogImageAlt,
   canonicalURL = getCanonicalURL(),
   pubDatetime,
   modDatetime,
+  pageType = "website",
+  structuredData = [],
+  noindex = false,
 } = Astro.props;
 
 const pathname = Astro.url.pathname;
-const isPostsIndex = pathname === "/posts" || pathname === "/posts/";
-const isPostDetail = pathname.startsWith("/posts/") && !isPostsIndex;
+const isArticle = pageType === "article";
 
 const socialImageURL = new URL(
   ogImage ?? SITE.ogImage ?? "og.png",
   Astro.url.origin
 ).href;
+const socialImageAlt = ogImageAlt ?? title;
 
-const structuredData =
-  isPostDetail && pubDatetime
-    ? {
-        "@context": "https://schema.org",
-        "@type": "BlogPosting",
-        headline: `${title}`,
-        image: `${socialImageURL}`,
-        datePublished: pubDatetime.toISOString(),
-        ...(modDatetime && { dateModified: modDatetime.toISOString() }),
-        author: [
-          {
-            "@type": "Person",
-            name: `${author}`,
-            url: `${profile}`,
-          },
-        ],
-      }
-    : null;
+const ogLocale = (LOCALE.langTag?.[0] ?? "en-US").replace("-", "_");
+
+const showBreadcrumbSchema = !noindex && !pathname.startsWith("/404");
+const schemas: Record<string, unknown>[] = [
+  ...(showBreadcrumbSchema
+    ? [breadcrumbSchema(getBreadcrumbItems(pathname))]
+    : []),
+  ...structuredData,
+];
 ---
 
 <!doctype html>
-<html lang=`${LOCALE.lang ?? "en"}`>
+<html lang={LOCALE.lang ?? "en"}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
@@ -100,20 +99,30 @@ const structuredData =
     <meta name="title" content={title} />
     <meta name="description" content={description} />
     <meta name="author" content={author} />
+    {noindex && <meta name="robots" content="noindex, follow" />}
     <link rel="sitemap" href="/sitemap-index.xml" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title={SITE.title}
+      href={new URL("rss.xml", Astro.site)}
+    />
 
     <!-- Open Graph / Facebook -->
+    <meta property="og:site_name" content={SITE.title} />
+    <meta property="og:locale" content={ogLocale} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalURL} />
-    {isPostDetail && <meta property="og:type" content="article" />}
-    {!isPostDetail && <meta property="og:type" content="website" />}
-
+    <meta property="og:type" content={isArticle ? "article" : "website"} />
     <meta property="og:image" content={socialImageURL} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content={socialImageAlt} />
 
     <!-- Article Published/Modified time -->
     {
-      pubDatetime && isPostDetail && (
+      pubDatetime && isArticle && (
         <meta
           property="article:published_time"
           content={pubDatetime.toISOString()}
@@ -121,7 +130,7 @@ const structuredData =
       )
     }
     {
-      modDatetime && isPostDetail && (
+      modDatetime && isArticle && (
         <meta
           property="article:modified_time"
           content={modDatetime.toISOString()}
@@ -130,20 +139,17 @@ const structuredData =
     }
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content={canonicalURL} />
-    <meta property="twitter:title" content={title} />
-    <meta property="twitter:description" content={description} />
-    <meta property="twitter:image" content={socialImageURL} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={socialImageURL} />
+    <meta name="twitter:image:alt" content={socialImageAlt} />
 
-    <!-- Google JSON-LD Structured data -->
+    <!-- JSON-LD Structured data (BreadcrumbList + page-specific schemas) -->
     {
-      structuredData && (
-        <script
-          type="application/ld+json"
-          set:html={JSON.stringify(structuredData)}
-        />
-      )
+      schemas.map(schema => (
+        <script type="application/ld+json" set:html={JSON.stringify(schema)} />
+      ))
     }
 
     <meta name="theme-color" content="#FFFFFF" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,6 +35,7 @@ export interface Props {
   pageType?: "website" | "article";
   structuredData?: Record<string, unknown>[];
   noindex?: boolean;
+  tags?: string[];
 }
 
 /** Ensure canonical URL has no trailing slash for directory-like pages (SEO consistency) */
@@ -60,6 +61,7 @@ const {
   pageType = "website",
   structuredData = [],
   noindex = false,
+  tags = [],
 } = Astro.props;
 
 const pathname = Astro.url.pathname;
@@ -136,6 +138,10 @@ const schemas: Record<string, unknown>[] = [
           content={modDatetime.toISOString()}
         />
       )
+    }
+    {
+      isArticle &&
+        tags.map(tag => <meta property="article:tag" content={tag} />)
     }
 
     <!-- Twitter -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,6 +36,9 @@ export interface Props {
   structuredData?: Record<string, unknown>[];
   noindex?: boolean;
   tags?: string[];
+  /** Human-readable name for the current page's breadcrumb (e.g. the post
+   *  title); without it the URL slug is used. */
+  breadcrumbName?: string;
 }
 
 /** Ensure canonical URL has no trailing slash for directory-like pages (SEO consistency) */
@@ -62,6 +65,7 @@ const {
   structuredData = [],
   noindex = false,
   tags = [],
+  breadcrumbName,
 } = Astro.props;
 
 const pathname = Astro.url.pathname;
@@ -75,13 +79,23 @@ const socialImageAlt = ogImageAlt ?? title;
 
 const ogLocale = (LOCALE.langTag?.[0] ?? "en-US").replace("-", "_");
 
-const showBreadcrumbSchema = !noindex && !pathname.startsWith("/404");
+const breadcrumbItems = getBreadcrumbItems(pathname);
+const lastCrumb = breadcrumbItems[breadcrumbItems.length - 1];
+if (breadcrumbName && lastCrumb) {
+  lastCrumb.name = breadcrumbName;
+}
+// Single-item trails (homepage) carry no information; noindex pages
+// (404, search) should not advertise structured data.
+const showBreadcrumbSchema = !noindex && breadcrumbItems.length >= 2;
 const schemas: Record<string, unknown>[] = [
-  ...(showBreadcrumbSchema
-    ? [breadcrumbSchema(getBreadcrumbItems(pathname))]
-    : []),
+  ...(showBreadcrumbSchema ? [breadcrumbSchema(breadcrumbItems)] : []),
   ...structuredData,
 ];
+
+/** `<` must be escaped inside an inline <script>: a title or description
+ *  containing "</script>" would otherwise terminate the element early. */
+const serializeSchema = (schema: Record<string, unknown>) =>
+  JSON.stringify(schema).replace(/</g, "\\u003c");
 ---
 
 <!doctype html>
@@ -154,7 +168,7 @@ const schemas: Record<string, unknown>[] = [
     <!-- JSON-LD Structured data (BreadcrumbList + page-specific schemas) -->
     {
       schemas.map(schema => (
-        <script type="application/ld+json" set:html={JSON.stringify(schema)} />
+        <script type="application/ld+json" set:html={serializeSchema(schema)} />
       ))
     }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -100,7 +100,7 @@ const schemas: Record<string, unknown>[] = [
     <meta name="description" content={description} />
     <meta name="author" content={author} />
     {noindex && <meta name="robots" content="noindex, follow" />}
-    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="sitemap" href="/sitemap.xml" />
     <link
       rel="alternate"
       type="application/rss+xml"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,6 +20,7 @@ import "@fontsource/ibm-plex-mono/400-italic.css";
 import { ViewTransitions } from "astro:transitions";
 import { getBreadcrumbItems } from "@utils/breadcrumbItems";
 import { breadcrumbSchema } from "@utils/structuredData";
+import { getCanonicalURL } from "@utils/canonicalURL";
 
 const googleSiteVerification = import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION;
 
@@ -29,6 +30,9 @@ export interface Props {
   description?: string;
   ogImage?: string;
   ogImageAlt?: string;
+  /** Intrinsic ogImage dimensions; omit when unknown (arbitrary URL paths). */
+  ogImageWidth?: number;
+  ogImageHeight?: number;
   canonicalURL?: string;
   pubDatetime?: Date;
   modDatetime?: Date | null;
@@ -41,24 +45,16 @@ export interface Props {
   breadcrumbName?: string;
 }
 
-/** Ensure canonical URL has no trailing slash for directory-like pages (SEO consistency) */
-function getCanonicalURL(): string {
-  const pathname = Astro.url.pathname;
-  const isFile = /\.(xml|txt|json|html?|webmanifest)$/i.test(pathname);
-  const path =
-    pathname && pathname.endsWith("/") && pathname.length > 1 && !isFile
-      ? pathname.slice(0, -1)
-      : pathname;
-  return new URL(path, Astro.site).href;
-}
-
 const {
   title = SITE.title,
   author = SITE.author,
   description = SITE.desc,
-  ogImage = SITE.ogImage,
+  ogImage,
   ogImageAlt,
-  canonicalURL = getCanonicalURL(),
+  // Without an explicit ogImage the page uses the generated /og.png (1200x630).
+  ogImageWidth = ogImage ? undefined : 1200,
+  ogImageHeight = ogImage ? undefined : 630,
+  canonicalURL = getCanonicalURL(Astro.url.pathname, Astro.site),
   pubDatetime,
   modDatetime,
   pageType = "website",
@@ -71,10 +67,7 @@ const {
 const pathname = Astro.url.pathname;
 const isArticle = pageType === "article";
 
-const socialImageURL = new URL(
-  ogImage ?? SITE.ogImage ?? "og.png",
-  Astro.url.origin
-).href;
+const socialImageURL = new URL(ogImage ?? "og.png", Astro.url.origin).href;
 const socialImageAlt = ogImageAlt ?? title;
 
 const ogLocale = (LOCALE.langTag?.[0] ?? "en-US").replace("-", "_");
@@ -132,8 +125,16 @@ const serializeSchema = (schema: Record<string, unknown>) =>
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:type" content={isArticle ? "article" : "website"} />
     <meta property="og:image" content={socialImageURL} />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    {
+      ogImageWidth && (
+        <meta property="og:image:width" content={String(ogImageWidth)} />
+      )
+    }
+    {
+      ogImageHeight && (
+        <meta property="og:image:height" content={String(ogImageHeight)} />
+      )
+    }
     <meta property="og:image:alt" content={socialImageAlt} />
 
     <!-- Article Published/Modified time -->

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -52,6 +52,7 @@ const layoutProps = {
   ogImage: ogUrl,
   ogImageAlt: title,
   pageType: "article" as const,
+  tags,
   structuredData: [
     blogPostingSchema({
       title,

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -12,6 +12,8 @@ import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import { filterTocHeadings } from "@utils/filterTocHeadings";
 import { blogPostingSchema } from "@utils/structuredData";
+import { getCanonicalURL } from "@utils/canonicalURL";
+import { resolveOgImage } from "@utils/ogImage";
 import { SITE } from "@config";
 export interface Props {
   post: CollectionEntry<"blog">;
@@ -33,13 +35,13 @@ const {
 
 const { Content, headings } = await post.render();
 
-const ogImageUrl = typeof ogImage === "string" ? ogImage : ogImage?.src;
-const ogUrl = new URL(
-  ogImageUrl ?? `/posts/${slugifyStr(title)}.png`,
+const og = resolveOgImage(
+  ogImage,
+  `/posts/${slugifyStr(title)}.png`,
   Astro.url.origin
-).href;
+);
 
-const pageUrl = canonicalURL ?? new URL(Astro.url.pathname, SITE.website).href;
+const pageUrl = canonicalURL ?? getCanonicalURL(Astro.url.pathname);
 const wordCount = post.body?.trim().split(/\s+/).length;
 
 const layoutProps = {
@@ -49,7 +51,9 @@ const layoutProps = {
   pubDatetime,
   modDatetime,
   canonicalURL,
-  ogImage: ogUrl,
+  ogImage: og.url,
+  ogImageWidth: og.width,
+  ogImageHeight: og.height,
   ogImageAlt: title,
   pageType: "article" as const,
   tags,
@@ -59,7 +63,7 @@ const layoutProps = {
       title,
       description,
       url: pageUrl,
-      image: ogUrl,
+      image: og.url,
       author,
       pubDatetime,
       modDatetime,

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -11,6 +11,7 @@ import PostPagination from "@components/riso/PostPagination";
 import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import { filterTocHeadings } from "@utils/filterTocHeadings";
+import { blogPostingSchema } from "@utils/structuredData";
 import { SITE } from "@config";
 export interface Props {
   post: CollectionEntry<"blog">;
@@ -38,6 +39,9 @@ const ogUrl = new URL(
   Astro.url.origin
 ).href;
 
+const pageUrl = canonicalURL ?? new URL(Astro.url.pathname, SITE.website).href;
+const wordCount = post.body?.trim().split(/\s+/).length;
+
 const layoutProps = {
   title: `${title} | ${SITE.title}`,
   author,
@@ -46,6 +50,21 @@ const layoutProps = {
   modDatetime,
   canonicalURL,
   ogImage: ogUrl,
+  ogImageAlt: title,
+  pageType: "article" as const,
+  structuredData: [
+    blogPostingSchema({
+      title,
+      description,
+      url: pageUrl,
+      image: ogUrl,
+      author,
+      pubDatetime,
+      modDatetime,
+      tags,
+      wordCount,
+    }),
+  ],
 };
 
 /* ========== Prev/Next Posts ========== */

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -53,6 +53,7 @@ const layoutProps = {
   ogImageAlt: title,
   pageType: "article" as const,
   tags,
+  breadcrumbName: title,
   structuredData: [
     blogPostingSchema({
       title,

--- a/src/layouts/Posts.astro
+++ b/src/layouts/Posts.astro
@@ -13,7 +13,10 @@ export interface Props {
 const { portfolioPosts, pageSize } = Astro.props;
 ---
 
-<Layout title={`Posts | ${SITE.title}`}>
+<Layout
+  title={`Posts | ${SITE.title}`}
+  description={`All blog posts by ${SITE.author} — frontend architecture, design systems, and production UI.`}
+>
   <Main pageTitle="Posts" showPageHeader={false} showBreadcrumbs={false}>
     <PostsIndexBoard client:load posts={portfolioPosts} pageSize={pageSize} />
   </Main>

--- a/src/layouts/SimplePage.astro
+++ b/src/layouts/SimplePage.astro
@@ -1,5 +1,6 @@
 ---
 import { SITE } from "@config";
+import { profilePageSchema } from "@utils/structuredData";
 import Layout from "./Layout.astro";
 import Main from "./Main.astro";
 
@@ -12,9 +13,16 @@ export interface Props {
 }
 
 const { frontmatter } = Astro.props;
+
+const structuredData =
+  frontmatter.activeNav === "about" ? [profilePageSchema()] : [];
 ---
 
-<Layout title={`${frontmatter.title} | ${SITE.title}`}>
+<Layout
+  title={`${frontmatter.title} | ${SITE.title}`}
+  description={frontmatter.description}
+  structuredData={structuredData}
+>
   <Main
     pageTitle={frontmatter.title}
     showPageHeader={false}

--- a/src/layouts/TagPosts.astro
+++ b/src/layouts/TagPosts.astro
@@ -21,6 +21,7 @@ const pageSuffix = page.currentPage > 1 ? ` (page ${page.currentPage})` : "";
 <Layout
   title={`Tag: ${tagName}${pageSuffix} | ${SITE.title}`}
   description={`All the posts with the tag "${tagName}".`}
+  breadcrumbName={`${tagName}${pageSuffix}`}
 >
   <Main
     pageTitle={[`Tag:`, `${tagName}`]}

--- a/src/layouts/TagPosts.astro
+++ b/src/layouts/TagPosts.astro
@@ -14,9 +14,14 @@ export interface Props {
 }
 
 const { page, tag, tagName } = Astro.props;
+
+const pageSuffix = page.currentPage > 1 ? ` (page ${page.currentPage})` : "";
 ---
 
-<Layout title={`Tag: ${tagName} | ${SITE.title}`}>
+<Layout
+  title={`Tag: ${tagName}${pageSuffix} | ${SITE.title}`}
+  description={`All the posts with the tag "${tagName}".`}
+>
   <Main
     pageTitle={[`Tag:`, `${tagName}`]}
     titleTransition={tag}

--- a/src/layouts/TagPosts.astro
+++ b/src/layouts/TagPosts.astro
@@ -21,7 +21,7 @@ const pageSuffix = page.currentPage > 1 ? ` (page ${page.currentPage})` : "";
 <Layout
   title={`Tag: ${tagName}${pageSuffix} | ${SITE.title}`}
   description={`All the posts with the tag "${tagName}".`}
-  breadcrumbName={`${tagName}${pageSuffix}`}
+  breadcrumbName={page.currentPage === 1 ? tagName : undefined}
 >
   <Main
     pageTitle={[`Tag:`, `${tagName}`]}

--- a/src/layouts/TagWork.astro
+++ b/src/layouts/TagWork.astro
@@ -21,7 +21,7 @@ const pageSuffix = page.currentPage > 1 ? ` (page ${page.currentPage})` : "";
 <Layout
   title={`Tech: ${tagName}${pageSuffix} | ${SITE.title}`}
   description={`All the work with the tag "${tagName}".`}
-  breadcrumbName={`${tagName}${pageSuffix}`}
+  breadcrumbName={page.currentPage === 1 ? tagName : undefined}
 >
   <Main
     pageTitle={[`Tech:`, `${tagName}`]}

--- a/src/layouts/TagWork.astro
+++ b/src/layouts/TagWork.astro
@@ -21,6 +21,7 @@ const pageSuffix = page.currentPage > 1 ? ` (page ${page.currentPage})` : "";
 <Layout
   title={`Tech: ${tagName}${pageSuffix} | ${SITE.title}`}
   description={`All the work with the tag "${tagName}".`}
+  breadcrumbName={`${tagName}${pageSuffix}`}
 >
   <Main
     pageTitle={[`Tech:`, `${tagName}`]}

--- a/src/layouts/TagWork.astro
+++ b/src/layouts/TagWork.astro
@@ -14,9 +14,14 @@ export interface Props {
 }
 
 const { page, tag, tagName } = Astro.props;
+
+const pageSuffix = page.currentPage > 1 ? ` (page ${page.currentPage})` : "";
 ---
 
-<Layout title={`Tech: ${tagName} | ${SITE.title}`}>
+<Layout
+  title={`Tech: ${tagName}${pageSuffix} | ${SITE.title}`}
+  description={`All the work with the tag "${tagName}".`}
+>
   <Main
     pageTitle={[`Tech:`, `${tagName}`]}
     titleTransition={tag}

--- a/src/layouts/Work.astro
+++ b/src/layouts/Work.astro
@@ -12,9 +12,14 @@ export interface Props {
 }
 
 const { page } = Astro.props;
+
+const pageSuffix = page.currentPage > 1 ? ` (page ${page.currentPage})` : "";
 ---
 
-<Layout title={`Work | ${SITE.title}`}>
+<Layout
+  title={`Work${pageSuffix} | ${SITE.title}`}
+  description={`Selected work and case studies by ${SITE.author}.`}
+>
   <Main pageTitle="Work" showBreadcrumbs={false}>
     <ul class="list-none pl-0">
       {

--- a/src/layouts/WorkDetails.astro
+++ b/src/layouts/WorkDetails.astro
@@ -54,6 +54,7 @@ const layoutProps = {
   ogImageAlt: title,
   pageType: "article" as const,
   tags,
+  breadcrumbName: title,
   structuredData: [
     creativeWorkSchema({
       title,

--- a/src/layouts/WorkDetails.astro
+++ b/src/layouts/WorkDetails.astro
@@ -11,6 +11,7 @@ import PostPagination from "@components/riso/PostPagination";
 import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import { filterTocHeadings } from "@utils/filterTocHeadings";
+import { creativeWorkSchema } from "@utils/structuredData";
 import { SITE } from "@config";
 export interface Props {
   work: CollectionEntry<"work">;
@@ -40,6 +41,8 @@ const ogUrl = new URL(
   Astro.url.origin
 ).href;
 
+const pageUrl = canonicalURL ?? new URL(Astro.url.pathname, SITE.website).href;
+
 const layoutProps = {
   title: `${title} | ${SITE.title}`,
   author,
@@ -48,6 +51,20 @@ const layoutProps = {
   modDatetime,
   canonicalURL,
   ogImage: ogUrl,
+  ogImageAlt: title,
+  pageType: "article" as const,
+  structuredData: [
+    creativeWorkSchema({
+      title,
+      description: description ?? summary,
+      url: pageUrl,
+      image: ogUrl,
+      author,
+      pubDatetime,
+      modDatetime,
+      tags,
+    }),
+  ],
 };
 
 const allWorks = works.map(({ data: { title: t }, slug }) => ({

--- a/src/layouts/WorkDetails.astro
+++ b/src/layouts/WorkDetails.astro
@@ -12,6 +12,8 @@ import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import { filterTocHeadings } from "@utils/filterTocHeadings";
 import { creativeWorkSchema } from "@utils/structuredData";
+import { getCanonicalURL } from "@utils/canonicalURL";
+import { resolveOgImage } from "@utils/ogImage";
 import { SITE } from "@config";
 export interface Props {
   work: CollectionEntry<"work">;
@@ -35,22 +37,24 @@ const {
 
 const { Content, headings } = await work.render();
 
-const ogImageUrl = typeof ogImage === "string" ? ogImage : ogImage?.src;
-const ogUrl = new URL(
-  ogImageUrl ?? `/work/${slugifyStr(title)}.png`,
+const og = resolveOgImage(
+  ogImage,
+  `/work/${slugifyStr(title)}.png`,
   Astro.url.origin
-).href;
+);
 
-const pageUrl = canonicalURL ?? new URL(Astro.url.pathname, SITE.website).href;
+const pageUrl = canonicalURL ?? getCanonicalURL(Astro.url.pathname);
 
 const layoutProps = {
   title: `${title} | ${SITE.title}`,
   author,
-  description,
+  description: description ?? summary,
   pubDatetime,
   modDatetime,
   canonicalURL,
-  ogImage: ogUrl,
+  ogImage: og.url,
+  ogImageWidth: og.width,
+  ogImageHeight: og.height,
   ogImageAlt: title,
   pageType: "article" as const,
   tags,
@@ -60,7 +64,7 @@ const layoutProps = {
       title,
       description: description ?? summary,
       url: pageUrl,
-      image: ogUrl,
+      image: og.url,
       author,
       pubDatetime,
       modDatetime,

--- a/src/layouts/WorkDetails.astro
+++ b/src/layouts/WorkDetails.astro
@@ -53,6 +53,7 @@ const layoutProps = {
   ogImage: ogUrl,
   ogImageAlt: title,
   pageType: "article" as const,
+  tags,
   structuredData: [
     creativeWorkSchema({
       title,

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,7 +5,7 @@ import LinkButton from "@components/LinkButton.astro";
 import RisoBoardShell from "@components/RisoBoardShell.astro";
 ---
 
-<Layout title={`404 Not Found | ${SITE.title}`}>
+<Layout title={`404 Not Found | ${SITE.title}`} noindex>
   <RisoBoardShell>
     <main id="main-content" class="app-layout board-slot">
       <div class="not-found-wrapper">

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/SimplePage.astro
 title: "About"
+description: "About Rachel Cantor — software engineer with 14+ years of experience building web, mobile, and cross-platform TV applications."
 activeNav: "about"
 ---
 import LinkButton from '../components/LinkButton.astro';

--- a/src/pages/accessibility.mdx
+++ b/src/pages/accessibility.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/SimplePage.astro
 title: "Accessibility Statement"
+description: "Accessibility statement for rachel.fyi — WCAG 2.1 AA conformance, feedback channels, and technical specifications."
 ---
 import LinkButton from '../components/LinkButton.astro';
 

--- a/src/pages/demos/[slug]/index.png.ts
+++ b/src/pages/demos/[slug]/index.png.ts
@@ -1,0 +1,23 @@
+import type { APIRoute } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+import { generateOgImageForDemo } from "@utils/generateOgImages";
+import { slugifyStr } from "@utils/slugify";
+
+export async function getStaticPaths() {
+  const demos = await getCollection("demos").then(p =>
+    p.filter(({ data }) => !data.draft && !data.ogImage)
+  );
+
+  return demos.map(demo => ({
+    params: { slug: slugifyStr(demo.data.title) },
+    props: demo,
+  }));
+}
+
+export const GET: APIRoute = async ({ props }) =>
+  new Response(
+    await generateOgImageForDemo(props as CollectionEntry<"demos">),
+    {
+      headers: { "Content-Type": "image/png" },
+    }
+  );

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import getSortedPosts from "@utils/getSortedPosts";
 import { mapBlogEntryToPortfolioPost } from "@utils/mapBlogToPortfolioPost";
 import getSortedWork from "@utils/getSortedWork";
 import getSortedDemos from "@utils/getSortedDemos";
+import { personSchema, websiteSchema } from "@utils/structuredData";
 
 const posts = await getCollection("blog");
 const sortedPosts = getSortedPosts(posts);
@@ -52,7 +53,7 @@ const portfolioDemos = homeDemosRaw.map(entry => ({
 }));
 ---
 
-<Layout>
+<Layout structuredData={[websiteSchema(), personSchema()]}>
   <RisoBoardShell animateNav>
     <main id="main-content" class="board-slot">
       <PortfolioBoard

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -2,11 +2,10 @@ import type { APIRoute } from "astro";
 import { SITE } from "@config";
 
 const robots = `
-User-agent: Googlebot
-Disallow: /nogooglebot/
-
 User-agent: *
 Allow: /
+Disallow: /admin
+Disallow: /search
 Disallow: /cdn-cgi/zaraz/
 
 Sitemap: ${new URL("sitemap-index.xml", SITE.website).href}

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -8,7 +8,7 @@ Disallow: /admin
 Disallow: /search
 Disallow: /cdn-cgi/zaraz/
 
-Sitemap: ${new URL("sitemap-index.xml", SITE.website).href}
+Sitemap: ${new URL("sitemap.xml", SITE.website).href}
 `.trim();
 
 export const GET: APIRoute = () =>

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,11 +1,12 @@
 import type { APIRoute } from "astro";
 import { SITE } from "@config";
 
+// /search is deliberately NOT disallowed here: it carries a noindex meta tag,
+// which crawlers can only see if they are allowed to fetch the page.
 const robots = `
 User-agent: *
 Allow: /
 Disallow: /admin
-Disallow: /search
 Disallow: /cdn-cgi/zaraz/
 
 Sitemap: ${new URL("sitemap.xml", SITE.website).href}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -11,7 +11,7 @@ export async function GET() {
     description: SITE.desc,
     site: SITE.website,
     items: sortedPosts.map(({ data, slug }) => ({
-      link: `posts/${slug}/`,
+      link: `posts/${slug}`,
       title: data.title,
       description: data.description,
       pubDate: new Date(data.modDatetime ?? data.pubDatetime),

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -10,6 +10,9 @@ export async function GET() {
     title: SITE.title,
     description: SITE.desc,
     site: SITE.website,
+    // Without this, @astrojs/rss re-appends the trailing slash the site's
+    // trailingSlash:"never" config (and vercel.json 301) strips.
+    trailingSlash: false,
     items: sortedPosts.map(({ data, slug }) => ({
       link: `posts/${slug}`,
       title: data.title,

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -13,7 +13,7 @@ const sortedPosts = getSortedPosts(posts);
 // List of items to search in
 const searchList = sortedPosts.map(({ data, slug }) => ({
   title: data.title,
-  description: data.description,
+  description: data.description ?? "",
   tags: data.tags,
   data,
   slug,

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -20,7 +20,11 @@ const searchList = sortedPosts.map(({ data, slug }) => ({
 }));
 ---
 
-<Layout title={`Search | ${SITE.title}`}>
+<Layout
+  title={`Search | ${SITE.title}`}
+  description={`Search blog posts on ${SITE.title}.`}
+  noindex
+>
   <Main pageTitle="Search" pageDesc="Search any post ...">
     <SearchBar client:load searchList={searchList} />
   </Main>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -2,9 +2,8 @@ import type { APIRoute } from "astro";
 import { getCollection, type CollectionEntry } from "astro:content";
 import { SITE } from "@config";
 import { getUniquePostTags, getUniqueWorkTags } from "@utils/getUniqueTags";
-import { getPostsByTag, getWorkByTag } from "@utils/getItemsByTag";
-import getSortedWork from "@utils/getSortedWork";
-import getSortedDemos from "@utils/getSortedDemos";
+import { postFilter, workFilter, demoFilter } from "@utils/filters";
+import { slugifyAll } from "@utils/slugify";
 
 /** Replaces @astrojs/sitemap so detail URLs can carry an accurate lastmod
  *  from frontmatter (modDatetime ?? pubDatetime). Listing URLs carry none —
@@ -15,25 +14,36 @@ interface SitemapEntry {
   lastmod?: Date;
 }
 
-// Routes without collection data. Keep in sync with src/pages — a new static
-// page must be added here by hand. /search is deliberately excluded (noindex).
-const STATIC_PATHS = [
-  "/",
-  "/about",
-  "/accessibility",
-  "/uses",
-  "/posts",
-  "/tags",
-  "/tech",
-];
+// Static routes derived from src/pages itself, so a new page cannot silently
+// drift out of the sitemap. Dynamic ([param]) routes are enumerated below;
+// noindex pages are excluded.
+const EXCLUDED_PATHS = new Set(["/search", "/404"]);
+const staticPageFiles = import.meta.glob("./**/*.{astro,mdx}");
+const STATIC_PATHS = Object.keys(staticPageFiles)
+  .filter(file => !file.includes("["))
+  .map(file => {
+    const route = "/" + file.replace(/^\.\//, "").replace(/\.(astro|mdx)$/, "");
+    return route === "/index" ? "/" : route.replace(/\/index$/, "");
+  })
+  .filter(path => !EXCLUDED_PATHS.has(path))
+  .sort();
 
 const absolute = (path: string) => new URL(path, SITE.website).href;
 
 type Dated = CollectionEntry<"blog" | "work" | "demos">;
 
-const lastmodOf = ({ data }: Dated) => data.modDatetime ?? data.pubDatetime;
+const buildTime = new Date();
 
-/** Mirror of Astro's paginate(): base path is page 1, /2.. for the rest. */
+/** modDatetime ?? pubDatetime, clamped: a future timestamp (scheduled or
+ *  mistyped frontmatter) is invalid in a sitemap and erodes lastmod trust. */
+const lastmodOf = ({ data }: Dated) => {
+  const lastmod = data.modDatetime ?? data.pubDatetime;
+  return lastmod > buildTime ? buildTime : lastmod;
+};
+
+/** Mirror of Astro's paginate(): base path is page 1, /2.. for the rest.
+ *  All [...page] routes paginate by SITE.postPerPage; if one ever diverges,
+ *  this must follow. */
 function paginatedPaths(basePath: string, itemCount: number): string[] {
   const pageCount = Math.max(1, Math.ceil(itemCount / SITE.postPerPage));
   return [
@@ -42,13 +52,34 @@ function paginatedPaths(basePath: string, itemCount: number): string[] {
   ];
 }
 
+/** Entry count per slugified tag in one pass (mirrors getItemsByTag). */
+function tagCounts(
+  entries: Array<CollectionEntry<"blog"> | CollectionEntry<"work">>
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    for (const tag of new Set(slugifyAll(entry.data.tags))) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+const escapeXml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/'/g, "&apos;")
+    .replace(/"/g, "&quot;");
+
 function toXml(entries: SitemapEntry[]): string {
   const urls = entries
     .map(({ loc, lastmod }) => {
       const lastmodTag = lastmod
         ? `<lastmod>${lastmod.toISOString()}</lastmod>`
         : "";
-      return `  <url><loc>${loc}</loc>${lastmodTag}</url>`;
+      return `  <url><loc>${escapeXml(loc)}</loc>${lastmodTag}</url>`;
     })
     .join("\n");
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -59,34 +90,39 @@ ${urls}
 }
 
 export const GET: APIRoute = async () => {
-  // Same predicate as the [slug] detail routes, so every built page is listed.
-  const posts = await getCollection("blog", ({ data }) => !data.draft);
-  const work = await getCollection("work", ({ data }) => !data.draft);
-  const demos = await getCollection("demos", ({ data }) => !data.draft);
+  // Time-aware filters match the listing routes. The [slug] routes build
+  // scheduled-future entries too, but advertising an embargoed URL (with a
+  // future lastmod) is exactly what a sitemap should not do — they join the
+  // sitemap on the first build after their publish time.
+  const posts = (await getCollection("blog")).filter(postFilter);
+  const work = (await getCollection("work")).filter(workFilter);
+  const demos = (await getCollection("demos")).filter(demoFilter);
 
   const entries: SitemapEntry[] = STATIC_PATHS.map(path => ({
     loc: absolute(path),
   }));
 
   // Paginated listing routes mirror their [...page] getStaticPaths inputs.
-  for (const path of paginatedPaths("/work", getSortedWork(work).length)) {
+  for (const path of paginatedPaths("/work", work.length)) {
     entries.push({ loc: absolute(path) });
   }
-  for (const path of paginatedPaths("/demos", getSortedDemos(demos).length)) {
+  for (const path of paginatedPaths("/demos", demos.length)) {
     entries.push({ loc: absolute(path) });
   }
+  const postTagCounts = tagCounts(posts);
   for (const { tag } of getUniquePostTags(posts)) {
     for (const path of paginatedPaths(
       `/tags/${tag}`,
-      getPostsByTag(posts, tag).length
+      postTagCounts.get(tag) ?? 0
     )) {
       entries.push({ loc: absolute(path) });
     }
   }
+  const workTagCounts = tagCounts(work);
   for (const { tag } of getUniqueWorkTags(work)) {
     for (const path of paginatedPaths(
       `/tech/${tag}`,
-      getWorkByTag(work, tag).length
+      workTagCounts.get(tag) ?? 0
     )) {
       entries.push({ loc: absolute(path) });
     }

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -18,11 +18,13 @@ interface SitemapEntry {
 // drift out of the sitemap. Dynamic ([param]) routes are enumerated below;
 // noindex pages are excluded.
 const EXCLUDED_PATHS = new Set(["/search", "/404"]);
-const staticPageFiles = import.meta.glob("./**/*.{astro,mdx}");
+// Every page extension Astro routes (.ts endpoints are deliberately absent).
+const staticPageFiles = import.meta.glob("./**/*.{astro,mdx,md,html}");
 const STATIC_PATHS = Object.keys(staticPageFiles)
   .filter(file => !file.includes("["))
   .map(file => {
-    const route = "/" + file.replace(/^\.\//, "").replace(/\.(astro|mdx)$/, "");
+    const route =
+      "/" + file.replace(/^\.\//, "").replace(/\.(astro|mdx|md|html)$/, "");
     return route === "/index" ? "/" : route.replace(/\/index$/, "");
   })
   .filter(path => !EXCLUDED_PATHS.has(path))

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,117 @@
+import type { APIRoute } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+import { SITE } from "@config";
+import { getUniquePostTags, getUniqueWorkTags } from "@utils/getUniqueTags";
+import { getPostsByTag, getWorkByTag } from "@utils/getItemsByTag";
+import getSortedWork from "@utils/getSortedWork";
+import getSortedDemos from "@utils/getSortedDemos";
+
+/** Replaces @astrojs/sitemap so detail URLs can carry an accurate lastmod
+ *  from frontmatter (modDatetime ?? pubDatetime). Listing URLs carry none —
+ *  a fabricated lastmod is worse than no lastmod. */
+
+interface SitemapEntry {
+  loc: string;
+  lastmod?: Date;
+}
+
+// Routes without collection data. Keep in sync with src/pages — a new static
+// page must be added here by hand. /search is deliberately excluded (noindex).
+const STATIC_PATHS = [
+  "/",
+  "/about",
+  "/accessibility",
+  "/uses",
+  "/posts",
+  "/tags",
+  "/tech",
+];
+
+const absolute = (path: string) => new URL(path, SITE.website).href;
+
+type Dated = CollectionEntry<"blog" | "work" | "demos">;
+
+const lastmodOf = ({ data }: Dated) => data.modDatetime ?? data.pubDatetime;
+
+/** Mirror of Astro's paginate(): base path is page 1, /2.. for the rest. */
+function paginatedPaths(basePath: string, itemCount: number): string[] {
+  const pageCount = Math.max(1, Math.ceil(itemCount / SITE.postPerPage));
+  return [
+    basePath,
+    ...Array.from({ length: pageCount - 1 }, (_, i) => `${basePath}/${i + 2}`),
+  ];
+}
+
+function toXml(entries: SitemapEntry[]): string {
+  const urls = entries
+    .map(({ loc, lastmod }) => {
+      const lastmodTag = lastmod
+        ? `<lastmod>${lastmod.toISOString()}</lastmod>`
+        : "";
+      return `  <url><loc>${loc}</loc>${lastmodTag}</url>`;
+    })
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+export const GET: APIRoute = async () => {
+  // Same predicate as the [slug] detail routes, so every built page is listed.
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  const work = await getCollection("work", ({ data }) => !data.draft);
+  const demos = await getCollection("demos", ({ data }) => !data.draft);
+
+  const entries: SitemapEntry[] = STATIC_PATHS.map(path => ({
+    loc: absolute(path),
+  }));
+
+  // Paginated listing routes mirror their [...page] getStaticPaths inputs.
+  for (const path of paginatedPaths("/work", getSortedWork(work).length)) {
+    entries.push({ loc: absolute(path) });
+  }
+  for (const path of paginatedPaths("/demos", getSortedDemos(demos).length)) {
+    entries.push({ loc: absolute(path) });
+  }
+  for (const { tag } of getUniquePostTags(posts)) {
+    for (const path of paginatedPaths(
+      `/tags/${tag}`,
+      getPostsByTag(posts, tag).length
+    )) {
+      entries.push({ loc: absolute(path) });
+    }
+  }
+  for (const { tag } of getUniqueWorkTags(work)) {
+    for (const path of paginatedPaths(
+      `/tech/${tag}`,
+      getWorkByTag(work, tag).length
+    )) {
+      entries.push({ loc: absolute(path) });
+    }
+  }
+
+  for (const post of posts) {
+    entries.push({
+      loc: absolute(`/posts/${post.slug}`),
+      lastmod: lastmodOf(post),
+    });
+  }
+  for (const workItem of work) {
+    entries.push({
+      loc: absolute(`/work/${workItem.slug}`),
+      lastmod: lastmodOf(workItem),
+    });
+  }
+  for (const demo of demos) {
+    entries.push({
+      loc: absolute(`/demos/${demo.slug}`),
+      lastmod: lastmodOf(demo),
+    });
+  }
+
+  return new Response(toXml(entries), {
+    headers: { "Content-Type": "application/xml" },
+  });
+};

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -11,7 +11,10 @@ const posts = await getCollection("blog");
 let tags = getUniquePostTags(posts);
 ---
 
-<Layout title={`Tags | ${SITE.title}`}>
+<Layout
+  title={`Tags | ${SITE.title}`}
+  description="All the tags used in posts."
+>
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul>
       {tags.map(({ tag }) => <Tag {tag} size="lg" />)}

--- a/src/pages/tech/index.astro
+++ b/src/pages/tech/index.astro
@@ -11,7 +11,10 @@ const work = await getCollection("work");
 let tech = getUniqueWorkTags(work);
 ---
 
-<Layout title={`Tech | ${SITE.title}`}>
+<Layout
+  title={`Tech | ${SITE.title}`}
+  description="All the work tagged by tech."
+>
   <Main pageTitle="Tech" pageDesc="All the work tagged by tech.">
     <ul>
       {tech.map(({ tag }) => <WorkTag {tag} size="lg" />)}

--- a/src/pages/uses.mdx
+++ b/src/pages/uses.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/SimplePage.astro
 title: "Uses"
+description: "The hardware, software, and tools Rachel Cantor uses day to day."
 ---
 import LinkButton from '../components/LinkButton.astro';
 import Arrow from '../components/Arrow.tsx';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,15 @@
 import type socialIcons from "@assets/socialIcons";
 
+// A non-disabled LinkButton must have an href (it renders an <a>); the
+// disabled state renders a <span>, so href is only optional there.
+// (Lives here rather than in LinkButton.astro because the Astro compiler
+// can't parse intersection types in frontmatter.)
+export type LinkButtonProps = {
+  className?: string;
+  ariaLabel?: string;
+  title?: string;
+} & ({ disabled: true; href?: string } | { disabled?: false; href: string });
+
 export type Site = {
   website: string;
   author: string;

--- a/src/utils/breadcrumbItems.ts
+++ b/src/utils/breadcrumbItems.ts
@@ -17,11 +17,27 @@ function nameForSegment(segment: string): string {
   return decoded.charAt(0).toUpperCase() + decoded.slice(1);
 }
 
-/**
- * Builds display list + hrefs from pathname. A trailing all-numeric segment
- * is a pagination index (e.g. /work/2, /tags/react/2) and folds into the
- * previous crumb as "(page N)".
- */
+/** Numeric tail on a route that actually paginates: /work/2, /demos/2
+ *  (arity 2) and /tags/x/2, /tech/x/2 (arity 3). Other numeric tails
+ *  (e.g. a post slug like /posts/2024) are content, not pagination.
+ *  A numeric DETAIL slug like /work/2048 is indistinguishable from
+ *  pagination by pathname alone; the detail layouts' breadcrumbName
+ *  override restores the real title for the final crumb in that case. */
+function paginationNumber(segments: string[]): string | null {
+  const last = segments[segments.length - 1] ?? "";
+  if (!/^\d+$/.test(last)) return null;
+  const base = segments[0];
+  if (segments.length === 2 && (base === "work" || base === "demos")) {
+    return last;
+  }
+  if (segments.length === 3 && (base === "tags" || base === "tech")) {
+    return last;
+  }
+  return null;
+}
+
+/** Builds display list + hrefs from pathname. Pagination pages keep every
+ *  ancestor crumb linked and end on an unlinked "Page N" crumb. */
 export function getBreadcrumbItems(pathname: string): BreadcrumbItem[] {
   const segments = pathname.replace(/\/+$/, "").split("/").filter(Boolean);
 
@@ -29,27 +45,33 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItem[] {
     return [{ label: "HOME", name: "Home", href: null }];
   }
 
-  let pageNumber: string | null = null;
-  if (
-    segments.length >= 2 &&
-    /^\d+$/.test(segments[segments.length - 1] ?? "")
-  ) {
-    pageNumber = segments.pop() ?? null;
+  const pageNumber = paginationNumber(segments);
+  if (pageNumber) {
+    segments.pop();
   }
 
   const items: BreadcrumbItem[] = [{ label: "HOME", name: "Home", href: "/" }];
 
   for (let i = 0; i < segments.length; i++) {
-    const isLast = i === segments.length - 1;
-    let name = nameForSegment(segments[i] ?? "");
-    if (isLast && pageNumber) {
-      name = `${name} (page ${pageNumber})`;
-    }
+    const name = nameForSegment(segments[i] ?? "");
     items.push({
       label: name.toUpperCase(),
       name,
-      href: isLast ? null : `/${segments.slice(0, i + 1).join("/")}`,
+      href: `/${segments.slice(0, i + 1).join("/")}`,
     });
+  }
+
+  if (pageNumber) {
+    items.push({
+      label: `PAGE ${pageNumber}`,
+      name: `Page ${pageNumber}`,
+      href: null,
+    });
+  } else {
+    const last = items[items.length - 1];
+    if (last) {
+      last.href = null;
+    }
   }
 
   return items;

--- a/src/utils/breadcrumbItems.ts
+++ b/src/utils/breadcrumbItems.ts
@@ -1,12 +1,17 @@
-/** Breadcrumb segments for Dymo trail; labels are uppercase for tape styling. */
+/** Breadcrumb segments for Dymo trail; `label` is uppercase for tape styling,
+ *  `name` keeps the human-readable form for BreadcrumbList JSON-LD. */
 
-export type BreadcrumbItem = { label: string; href: string | null };
+export type BreadcrumbItem = {
+  label: string;
+  name: string;
+  href: string | null;
+};
 
-function labelForSegment(segment: string): string {
+function nameForSegment(segment: string): string {
   try {
-    return decodeURIComponent(segment).toUpperCase();
+    return decodeURIComponent(segment);
   } catch {
-    return segment.toUpperCase();
+    return segment;
   }
 }
 
@@ -19,7 +24,7 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItem[] {
   const raw = currentUrlPath.split("/").filter(Boolean);
 
   if (raw.length === 0) {
-    return [{ label: "HOME", href: null }];
+    return [{ label: "HOME", name: "Home", href: null }];
   }
 
   const breadcrumbList = currentUrlPath.split("/").slice(1);
@@ -48,15 +53,16 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItem[] {
     breadcrumbList.splice(1, 3, pagePart ? `${tagName} ${pagePart}` : tagName);
   }
 
-  const items: BreadcrumbItem[] = [{ label: "HOME", href: "/" }];
+  const items: BreadcrumbItem[] = [{ label: "HOME", name: "Home", href: "/" }];
 
   for (let i = 0; i < breadcrumbList.length; i++) {
     const isLast = i === breadcrumbList.length - 1;
     const segment = breadcrumbList[i] ?? "";
-    const label = labelForSegment(segment);
+    const name = nameForSegment(segment);
+    const label = name.toUpperCase();
 
     if (isLast) {
-      items.push({ label, href: null });
+      items.push({ label, name, href: null });
       continue;
     }
 
@@ -79,7 +85,7 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItem[] {
       href = `/${raw.slice(0, i + 1).join("/")}`;
     }
 
-    items.push({ label, href });
+    items.push({ label, name, href });
   }
 
   return items;

--- a/src/utils/breadcrumbItems.ts
+++ b/src/utils/breadcrumbItems.ts
@@ -8,84 +8,48 @@ export type BreadcrumbItem = {
 };
 
 function nameForSegment(segment: string): string {
+  let decoded = segment;
   try {
-    return decodeURIComponent(segment);
+    decoded = decodeURIComponent(segment);
   } catch {
-    return segment;
+    // keep the raw segment
   }
+  return decoded.charAt(0).toUpperCase() + decoded.slice(1);
 }
 
 /**
- * Builds display list + hrefs from pathname.
- * Merges `/posts` and `/posts/N` into "Posts (page N)"; keeps `/posts/slug` as two crumbs.
+ * Builds display list + hrefs from pathname. A trailing all-numeric segment
+ * is a pagination index (e.g. /work/2, /tags/react/2) and folds into the
+ * previous crumb as "(page N)".
  */
 export function getBreadcrumbItems(pathname: string): BreadcrumbItem[] {
-  const currentUrlPath = pathname.replace(/\/+$/, "");
-  const raw = currentUrlPath.split("/").filter(Boolean);
+  const segments = pathname.replace(/\/+$/, "").split("/").filter(Boolean);
 
-  if (raw.length === 0) {
+  if (segments.length === 0) {
     return [{ label: "HOME", name: "Home", href: null }];
   }
 
-  const breadcrumbList = currentUrlPath.split("/").slice(1);
-
-  if (breadcrumbList[0] === "posts") {
-    if (breadcrumbList.length === 1) {
-      breadcrumbList.splice(0, 1, `Posts (page 1)`);
-    } else if (
-      breadcrumbList.length === 2 &&
-      /^\d+$/.test(breadcrumbList[1] ?? "")
-    ) {
-      breadcrumbList.splice(0, 2, `Posts (page ${breadcrumbList[1]})`);
-    }
-  }
-
+  let pageNumber: string | null = null;
   if (
-    (breadcrumbList[0] === "tags" || breadcrumbList[0] === "tech") &&
-    breadcrumbList.length >= 3 &&
-    !isNaN(Number(breadcrumbList[2]))
+    segments.length >= 2 &&
+    /^\d+$/.test(segments[segments.length - 1] ?? "")
   ) {
-    const tagName = breadcrumbList[1] ?? "";
-    const pagePart =
-      breadcrumbList[2] === "" || Number(breadcrumbList[2]) === 1
-        ? ""
-        : `(page ${breadcrumbList[2]})`;
-    breadcrumbList.splice(1, 3, pagePart ? `${tagName} ${pagePart}` : tagName);
+    pageNumber = segments.pop() ?? null;
   }
 
   const items: BreadcrumbItem[] = [{ label: "HOME", name: "Home", href: "/" }];
 
-  for (let i = 0; i < breadcrumbList.length; i++) {
-    const isLast = i === breadcrumbList.length - 1;
-    const segment = breadcrumbList[i] ?? "";
-    const name = nameForSegment(segment);
-    const label = name.toUpperCase();
-
-    if (isLast) {
-      items.push({ label, name, href: null });
-      continue;
+  for (let i = 0; i < segments.length; i++) {
+    const isLast = i === segments.length - 1;
+    let name = nameForSegment(segments[i] ?? "");
+    if (isLast && pageNumber) {
+      name = `${name} (page ${pageNumber})`;
     }
-
-    let href: string;
-    if (breadcrumbList.length === raw.length) {
-      href = `/${raw.slice(0, i + 1).join("/")}`;
-    } else if (
-      segment.startsWith("Posts") &&
-      raw[0] === "posts" &&
-      raw.length >= 2
-    ) {
-      href = `/${raw.slice(0, 2).join("/")}`;
-    } else if (
-      breadcrumbList.length === 2 &&
-      raw.length === 3 &&
-      (raw[0] === "tags" || raw[0] === "tech")
-    ) {
-      href = i === 0 ? `/${raw[0]}` : `/${raw.slice(0, 3).join("/")}`;
-    } else {
-      href = `/${raw.slice(0, i + 1).join("/")}`;
-    }
-
-    items.push({ label, name, href });
+    items.push({
+      label: name.toUpperCase(),
+      name,
+      href: isLast ? null : `/${segments.slice(0, i + 1).join("/")}`,
+    });
   }
 
   return items;

--- a/src/utils/canonicalURL.ts
+++ b/src/utils/canonicalURL.ts
@@ -1,0 +1,13 @@
+import { SITE } from "@config";
+
+/** Canonical URLs have no trailing slash for directory-like pages
+ *  (trailingSlash: "never"); file-like paths keep their name untouched.
+ *  Single source for <link rel="canonical"> and JSON-LD url/@id values. */
+export function getCanonicalURL(pathname: string, base?: string | URL): string {
+  const isFile = /\.(xml|txt|json|html?|webmanifest)$/i.test(pathname);
+  const path =
+    pathname && pathname.endsWith("/") && pathname.length > 1 && !isFile
+      ? pathname.slice(0, -1)
+      : pathname;
+  return new URL(path, base ?? SITE.website).href;
+}

--- a/src/utils/generateOgImages.tsx
+++ b/src/utils/generateOgImages.tsx
@@ -1,28 +1,24 @@
 import satori, { type SatoriOptions } from "satori";
 import { Resvg } from "@resvg/resvg-js";
 import { type CollectionEntry } from "astro:content";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import postOgImage from "./og-templates/post";
 import siteOgImage from "./og-templates/site";
 import workOgImage from "./og-templates/work";
 import demoOgImage from "./og-templates/demo";
 
-const fetchFonts = async () => {
-  // Regular Font
-  const fontFileRegular = await fetch(
-    "https://www.1001fonts.com/download/font/ibm-plex-mono.regular.ttf"
-  );
-  const fontRegular: ArrayBuffer = await fontFileRegular.arrayBuffer();
+// Fonts come from the installed @fontsource package (already a dependency)
+// so builds don't depend on fetching TTFs from the network.
+const require = createRequire(import.meta.url);
 
-  // Bold Font
-  const fontFileBold = await fetch(
-    "https://www.1001fonts.com/download/font/ibm-plex-mono.bold.ttf"
-  );
-  const fontBold: ArrayBuffer = await fontFileBold.arrayBuffer();
+const loadFont = (file: string) =>
+  readFileSync(require.resolve(`@fontsource/ibm-plex-mono/files/${file}`));
 
-  return { fontRegular, fontBold };
-};
-
-const { fontRegular, fontBold } = await fetchFonts();
+const fontRegular = loadFont("ibm-plex-mono-latin-400-normal.woff");
+// The 700 weight matches the bold TTF this previously fetched; it stays
+// declared as 600 below so template font-weight resolution is unchanged.
+const fontBold = loadFont("ibm-plex-mono-latin-700-normal.woff");
 
 const options: SatoriOptions = {
   width: 1200,

--- a/src/utils/generateOgImages.tsx
+++ b/src/utils/generateOgImages.tsx
@@ -19,6 +19,10 @@ const fontRegular = loadFont("ibm-plex-mono-latin-400-normal.woff");
 // The 700 weight matches the bold TTF this previously fetched; it stays
 // declared as 600 below so template font-weight resolution is unchanged.
 const fontBold = loadFont("ibm-plex-mono-latin-700-normal.woff");
+// latin-ext keeps accented titles (Łukasz, Škoda…) from rendering as blanks;
+// satori falls back across same-family entries per glyph.
+const fontRegularExt = loadFont("ibm-plex-mono-latin-ext-400-normal.woff");
+const fontBoldExt = loadFont("ibm-plex-mono-latin-ext-700-normal.woff");
 
 const options: SatoriOptions = {
   width: 1200,
@@ -33,7 +37,19 @@ const options: SatoriOptions = {
     },
     {
       name: "IBM Plex Mono",
+      data: fontRegularExt,
+      weight: 400,
+      style: "normal",
+    },
+    {
+      name: "IBM Plex Mono",
       data: fontBold,
+      weight: 600,
+      style: "normal",
+    },
+    {
+      name: "IBM Plex Mono",
+      data: fontBoldExt,
       weight: 600,
       style: "normal",
     },

--- a/src/utils/generateOgImages.tsx
+++ b/src/utils/generateOgImages.tsx
@@ -4,6 +4,7 @@ import { type CollectionEntry } from "astro:content";
 import postOgImage from "./og-templates/post";
 import siteOgImage from "./og-templates/site";
 import workOgImage from "./og-templates/work";
+import demoOgImage from "./og-templates/demo";
 
 const fetchFonts = async () => {
   // Regular Font
@@ -56,6 +57,11 @@ export async function generateOgImageForPost(post: CollectionEntry<"blog">) {
 
 export async function generateOgImageForWork(work: CollectionEntry<"work">) {
   const svg = await satori(workOgImage(work), options);
+  return svgBufferToPngBuffer(svg);
+}
+
+export async function generateOgImageForDemo(demo: CollectionEntry<"demos">) {
+  const svg = await satori(demoOgImage(demo), options);
   return svgBufferToPngBuffer(svg);
 }
 

--- a/src/utils/og-templates/card.tsx
+++ b/src/utils/og-templates/card.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react";
+
+/** Shared satori frame for all OG images: paper card with offset double
+ *  border. Collection templates only supply the title and footer content. */
+export default function card({
+  title,
+  footer,
+}: {
+  title: string;
+  footer: ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        background: "#F5F0E8",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: "-1px",
+          right: "-1px",
+          border: "4px solid #1A1A2E",
+          background: "#EDE8D8",
+          opacity: "0.9",
+          borderRadius: "4px",
+          display: "flex",
+          justifyContent: "center",
+          margin: "2.5rem",
+          width: "88%",
+          height: "80%",
+        }}
+      />
+
+      <div
+        style={{
+          border: "4px solid #1A1A2E",
+          background: "#F5F0E8",
+          borderRadius: "4px",
+          display: "flex",
+          justifyContent: "center",
+          margin: "2rem",
+          width: "88%",
+          height: "80%",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            margin: "20px",
+            width: "90%",
+            height: "90%",
+          }}
+        >
+          <p
+            style={{
+              fontSize: 72,
+              fontWeight: "bold",
+              maxHeight: "84%",
+              overflow: "hidden",
+            }}
+          >
+            {title}
+          </p>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              width: "100%",
+              marginBottom: "8px",
+              fontSize: 28,
+            }}
+          >
+            {footer}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/utils/og-templates/demo.tsx
+++ b/src/utils/og-templates/demo.tsx
@@ -1,0 +1,85 @@
+import { SITE } from "@config";
+import type { CollectionEntry } from "astro:content";
+
+export default (demo: CollectionEntry<"demos">) => {
+  return (
+    <div
+      style={{
+        background: "#F5F0E8",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: "-1px",
+          right: "-1px",
+          border: "4px solid #1A1A2E",
+          background: "#EDE8D8",
+          opacity: "0.9",
+          borderRadius: "4px",
+          display: "flex",
+          justifyContent: "center",
+          margin: "2.5rem",
+          width: "88%",
+          height: "80%",
+        }}
+      />
+
+      <div
+        style={{
+          border: "4px solid #1A1A2E",
+          background: "#F5F0E8",
+          borderRadius: "4px",
+          display: "flex",
+          justifyContent: "center",
+          margin: "2rem",
+          width: "88%",
+          height: "80%",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            margin: "20px",
+            width: "90%",
+            height: "90%",
+          }}
+        >
+          <p
+            style={{
+              fontSize: 72,
+              fontWeight: "bold",
+              maxHeight: "84%",
+              overflow: "hidden",
+            }}
+          >
+            {demo.data.title}
+          </p>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              width: "100%",
+              marginBottom: "8px",
+              fontSize: 28,
+            }}
+          >
+            <p style={{ fontWeight: "bold" }}>
+              {demo.data.summary ?? demo.data.description}
+            </p>
+            <p style={{ overflow: "hidden", fontWeight: "bold" }}>
+              {SITE.title}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/utils/og-templates/demo.tsx
+++ b/src/utils/og-templates/demo.tsx
@@ -1,85 +1,16 @@
 import { SITE } from "@config";
 import type { CollectionEntry } from "astro:content";
+import card from "./card";
 
-export default (demo: CollectionEntry<"demos">) => {
-  return (
-    <div
-      style={{
-        background: "#F5F0E8",
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <div
-        style={{
-          position: "absolute",
-          top: "-1px",
-          right: "-1px",
-          border: "4px solid #1A1A2E",
-          background: "#EDE8D8",
-          opacity: "0.9",
-          borderRadius: "4px",
-          display: "flex",
-          justifyContent: "center",
-          margin: "2.5rem",
-          width: "88%",
-          height: "80%",
-        }}
-      />
-
-      <div
-        style={{
-          border: "4px solid #1A1A2E",
-          background: "#F5F0E8",
-          borderRadius: "4px",
-          display: "flex",
-          justifyContent: "center",
-          margin: "2rem",
-          width: "88%",
-          height: "80%",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-between",
-            margin: "20px",
-            width: "90%",
-            height: "90%",
-          }}
-        >
-          <p
-            style={{
-              fontSize: 72,
-              fontWeight: "bold",
-              maxHeight: "84%",
-              overflow: "hidden",
-            }}
-          >
-            {demo.data.title}
-          </p>
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              width: "100%",
-              marginBottom: "8px",
-              fontSize: 28,
-            }}
-          >
-            <p style={{ fontWeight: "bold" }}>
-              {demo.data.summary ?? demo.data.description}
-            </p>
-            <p style={{ overflow: "hidden", fontWeight: "bold" }}>
-              {SITE.title}
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
+export default (demo: CollectionEntry<"demos">) =>
+  card({
+    title: demo.data.title,
+    footer: [
+      <p key="summary" style={{ fontWeight: "bold" }}>
+        {demo.data.description ?? demo.data.summary}
+      </p>,
+      <p key="site" style={{ overflow: "hidden", fontWeight: "bold" }}>
+        {SITE.title}
+      </p>,
+    ],
+  });

--- a/src/utils/og-templates/post.tsx
+++ b/src/utils/og-templates/post.tsx
@@ -1,92 +1,22 @@
-import { SITE } from "@config";
 import type { CollectionEntry } from "astro:content";
+import card from "./card";
 
-export default (post: CollectionEntry<"blog">) => {
-  return (
-    <div
-      style={{
-        background: "#F5F0E8",
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <div
-        style={{
-          position: "absolute",
-          top: "-1px",
-          right: "-1px",
-          border: "4px solid #1A1A2E",
-          background: "#EDE8D8",
-          opacity: "0.9",
-          borderRadius: "4px",
-          display: "flex",
-          justifyContent: "center",
-          margin: "2.5rem",
-          width: "88%",
-          height: "80%",
-        }}
-      />
-
-      <div
-        style={{
-          border: "4px solid #1A1A2E",
-          background: "#F5F0E8",
-          borderRadius: "4px",
-          display: "flex",
-          justifyContent: "center",
-          margin: "2rem",
-          width: "88%",
-          height: "80%",
-        }}
-      >
-        <div
+export default (post: CollectionEntry<"blog">) =>
+  card({
+    title: post.data.title,
+    footer: (
+      <span>
+        by{" "}
+        <span
           style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-between",
-            margin: "20px",
-            width: "90%",
-            height: "90%",
+            color: "transparent",
           }}
         >
-          <p
-            style={{
-              fontSize: 72,
-              fontWeight: "bold",
-              maxHeight: "84%",
-              overflow: "hidden",
-            }}
-          >
-            {post.data.title}
-          </p>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "flex-start",
-              width: "100%",
-              marginBottom: "8px",
-              fontSize: 28,
-            }}
-          >
-            <span>
-              by{" "}
-              <span
-                style={{
-                  color: "transparent",
-                }}
-              >
-                "
-              </span>
-              <span style={{ overflow: "hidden", fontWeight: "bold" }}>
-                {post.data.author}
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
+          "
+        </span>
+        <span style={{ overflow: "hidden", fontWeight: "bold" }}>
+          {post.data.author}
+        </span>
+      </span>
+    ),
+  });

--- a/src/utils/og-templates/work.tsx
+++ b/src/utils/og-templates/work.tsx
@@ -1,83 +1,16 @@
 import { SITE } from "@config";
 import type { CollectionEntry } from "astro:content";
+import card from "./card";
 
-export default (work: CollectionEntry<"work">) => {
-  return (
-    <div
-      style={{
-        background: "#F5F0E8",
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <div
-        style={{
-          position: "absolute",
-          top: "-1px",
-          right: "-1px",
-          border: "4px solid #1A1A2E",
-          background: "#EDE8D8",
-          opacity: "0.9",
-          borderRadius: "4px",
-          display: "flex",
-          justifyContent: "center",
-          margin: "2.5rem",
-          width: "88%",
-          height: "80%",
-        }}
-      />
-
-      <div
-        style={{
-          border: "4px solid #1A1A2E",
-          background: "#F5F0E8",
-          borderRadius: "4px",
-          display: "flex",
-          justifyContent: "center",
-          margin: "2rem",
-          width: "88%",
-          height: "80%",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-between",
-            margin: "20px",
-            width: "90%",
-            height: "90%",
-          }}
-        >
-          <p
-            style={{
-              fontSize: 72,
-              fontWeight: "bold",
-              maxHeight: "84%",
-              overflow: "hidden",
-            }}
-          >
-            {work.data.title}
-          </p>
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              width: "100%",
-              marginBottom: "8px",
-              fontSize: 28,
-            }}
-          >
-            <p style={{ fontWeight: "bold" }}>{work.data.description}</p>
-            <p style={{ overflow: "hidden", fontWeight: "bold" }}>
-              {SITE.title}
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
+export default (work: CollectionEntry<"work">) =>
+  card({
+    title: work.data.title,
+    footer: [
+      <p key="summary" style={{ fontWeight: "bold" }}>
+        {work.data.description ?? work.data.summary}
+      </p>,
+      <p key="site" style={{ overflow: "hidden", fontWeight: "bold" }}>
+        {SITE.title}
+      </p>,
+    ],
+  });

--- a/src/utils/ogImage.ts
+++ b/src/utils/ogImage.ts
@@ -1,0 +1,33 @@
+import type { ImageMetadata } from "astro";
+
+export interface ResolvedOgImage {
+  url: string;
+  width?: number;
+  height?: number;
+}
+
+/** Resolve a frontmatter ogImage (resolved image, URL string, or absent) to
+ *  an absolute URL plus dimensions when they are actually known. The
+ *  generated fallback images are always 1200x630 (see generateOgImages.tsx);
+ *  a string path has unknown dimensions, so none are advertised. */
+export function resolveOgImage(
+  ogImage: ImageMetadata | string | undefined,
+  fallbackPath: string,
+  origin: string
+): ResolvedOgImage {
+  if (!ogImage) {
+    return {
+      url: new URL(fallbackPath, origin).href,
+      width: 1200,
+      height: 630,
+    };
+  }
+  if (typeof ogImage === "string") {
+    return { url: new URL(ogImage, origin).href };
+  }
+  return {
+    url: new URL(ogImage.src, origin).href,
+    width: ogImage.width,
+    height: ogImage.height,
+  };
+}

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -26,8 +26,13 @@ export function personSchema(): Schema {
   };
 }
 
-/** Site-wide WebSite schema (homepage). No SearchAction: Google retired the
- *  sitelinks search box rich result; `/search?q=` exists if ever wanted. */
+/** Reference to the Person node defined elsewhere on the same page —
+ *  JSON-LD consumers merge nodes by @id across script tags. */
+const personRef = (): Schema => ({ "@id": PERSON_ID });
+
+/** Site-wide WebSite schema (homepage). Pair with personSchema() on the same
+ *  page — publisher is only an @id reference. No SearchAction: Google retired
+ *  the sitelinks search box rich result; `/search?q=` exists if ever wanted. */
 export function websiteSchema(): Schema {
   return {
     "@context": "https://schema.org",
@@ -35,7 +40,7 @@ export function websiteSchema(): Schema {
     name: SITE.title,
     url: SITE.website,
     description: SITE.desc,
-    publisher: personEntity(),
+    publisher: personRef(),
   };
 }
 
@@ -59,13 +64,8 @@ interface ArticleSchemaInput {
   wordCount?: number;
 }
 
-/** Frontmatter `author` defaults to SITE.author; only a guest author needs a
- *  standalone Person without the site-wide @id. */
-function authorEntity(author?: string): Schema {
-  return author && author !== SITE.author
-    ? { "@type": "Person", name: author }
-    : personEntity();
-}
+const isGuestAuthor = (author?: string) =>
+  Boolean(author) && author !== SITE.author;
 
 function articleFields({
   url,
@@ -84,8 +84,12 @@ function articleFields({
     ...(description && { description }),
     ...(pubDatetime && { datePublished: pubDatetime.toISOString() }),
     ...(modDatetime && { dateModified: modDatetime.toISOString() }),
-    author: authorEntity(author),
-    publisher: personEntity(),
+    // The full Person node appears once per page; the second mention is an
+    // @id reference. A guest author flips which slot carries the full node.
+    author: isGuestAuthor(author)
+      ? { "@type": "Person", name: author }
+      : personEntity(),
+    publisher: isGuestAuthor(author) ? personEntity() : personRef(),
     ...(tags && tags.length > 0 && { keywords: tags.join(", ") }),
     ...(wordCount && { wordCount }),
   };

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,0 +1,126 @@
+/** JSON-LD schema.org builders. Each top-level builder returns a plain object
+ *  ready for `JSON.stringify` into a `<script type="application/ld+json">`. */
+
+import { SITE, SOCIALS } from "@config";
+import type { BreadcrumbItem } from "@utils/breadcrumbItems";
+
+type Schema = Record<string, unknown>;
+
+const PERSON_ID = `${SITE.website}/#person`;
+
+/** Person entity embedded inside other schemas (no @context). */
+function personEntity(): Schema {
+  return {
+    "@type": "Person",
+    "@id": PERSON_ID,
+    name: SITE.author,
+    url: SITE.website,
+    sameAs: SOCIALS.filter(social => social.active).map(social => social.href),
+  };
+}
+
+export function personSchema(): Schema {
+  return {
+    "@context": "https://schema.org",
+    ...personEntity(),
+  };
+}
+
+/** Site-wide WebSite schema (homepage). No SearchAction: Google retired the
+ *  sitelinks search box rich result; `/search?q=` exists if ever wanted. */
+export function websiteSchema(): Schema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE.title,
+    url: SITE.website,
+    description: SITE.desc,
+    publisher: personEntity(),
+  };
+}
+
+export function profilePageSchema(): Schema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    mainEntity: personEntity(),
+  };
+}
+
+interface ArticleSchemaInput {
+  title: string;
+  url: string;
+  image: string;
+  description?: string;
+  author?: string;
+  pubDatetime?: Date;
+  modDatetime?: Date | null;
+  tags?: string[];
+  wordCount?: number;
+}
+
+/** Frontmatter `author` defaults to SITE.author; only a guest author needs a
+ *  standalone Person without the site-wide @id. */
+function authorEntity(author?: string): Schema {
+  return author && author !== SITE.author
+    ? { "@type": "Person", name: author }
+    : personEntity();
+}
+
+function articleFields({
+  url,
+  image,
+  description,
+  author,
+  pubDatetime,
+  modDatetime,
+  tags,
+  wordCount,
+}: ArticleSchemaInput): Schema {
+  return {
+    url,
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    image,
+    ...(description && { description }),
+    ...(pubDatetime && { datePublished: pubDatetime.toISOString() }),
+    ...(modDatetime && { dateModified: modDatetime.toISOString() }),
+    author: authorEntity(author),
+    publisher: personEntity(),
+    ...(tags && tags.length > 0 && { keywords: tags.join(", ") }),
+    ...(wordCount && { wordCount }),
+  };
+}
+
+export function blogPostingSchema(input: ArticleSchemaInput): Schema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: input.title,
+    ...articleFields(input),
+  };
+}
+
+/** Work and demo pages: CreativeWork keeps validators happy without the
+ *  offers/ratings requirements SoftwareApplication would trigger. */
+export function creativeWorkSchema(input: ArticleSchemaInput): Schema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name: input.title,
+    ...articleFields(input),
+  };
+}
+
+export function breadcrumbSchema(items: BreadcrumbItem[]): Schema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      // The current page (href: null) carries no item, per Google's docs.
+      ...(item.href && { item: new URL(item.href, SITE.website).href }),
+    })),
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,20 @@
 {
     "cleanUrls": true,
     "redirects": [
-      { 
-        "source": "/:path+/", 
-        "destination": "/:path+", 
-        "permanent": true 
+      {
+        "source": "/:path+/",
+        "destination": "/:path+",
+        "permanent": true
+      },
+      {
+        "source": "/sitemap-index.xml",
+        "destination": "/sitemap.xml",
+        "permanent": true
+      },
+      {
+        "source": "/sitemap-0.xml",
+        "destination": "/sitemap.xml",
+        "permanent": true
       }
     ]
   }


### PR DESCRIPTION
## Summary

Implements SEO best practices across the site. Verified against a full build: Lighthouse SEO scores 100 on homepage, post, and demo pages.

### Structured data (JSON-LD)
- **BreadcrumbList on every indexable page** — visual breadcrumbs existed but emitted no structured data. Built from the same `getBreadcrumbItems` utility (extended with human-readable `name` alongside the uppercase Dymo `label`)
- New `src/utils/structuredData.ts` builder module; layouts pass schemas as props (replaces pathname sniffing in `Layout.astro`)
- WebSite + Person schema on homepage, ProfilePage on /about
- BlogPosting enriched with description, url, mainEntityOfPage, publisher, keywords, wordCount
- CreativeWork schema on work and demo pages (previously had no structured data)

### Bug fix: demo OG images were 404s
Demo pages referenced `/demos/{slug}.png` but no endpoint generated them — every demo share card had a broken image. Added a Satori endpoint + template mirroring posts/work.

### Meta tags
- Twitter cards now use `name=` attributes (were `property=`, ignored by some parsers); dropped non-standard `twitter:url`
- Added og:site_name, og:locale, og:image width/height/alt, twitter:image:alt, article:tag, RSS autodiscovery link

### Indexing hygiene
- noindex on /search and /404; robots.txt disallows /admin (TinaCMS) and /search, drops nogooglebot boilerplate (keeps the Zaraz line — that's how GA loads)
- Unique titles (page-numbered for pagination) and meta descriptions on tag/tech/work/demos/posts/static pages — all previously emitted the generic site description
- Web manifest name/short_name filled; `en-EN` langTag corrected to `en-US`

### Custom sitemap with accurate lastmod
Replaced `@astrojs/sitemap` with `src/pages/sitemap.xml.ts` — content URLs carry `lastmod` from `modDatetime ?? pubDatetime`. Verified parity: every built page except /search and /404 is listed, no phantom URLs. Sitemap moved from `/sitemap-index.xml` to `/sitemap.xml`. RSS links also drop the trailing slash to match `trailingSlash: "never"`.

### Build & repo hygiene
- OG fonts now load from the installed `@fontsource/ibm-plex-mono` package instead of fetching TTFs from 1001fonts.com at build time
- Fixed the three pre-existing type errors (`LinkButton` href is optional since the disabled state renders a span; search list description falls back to empty string) — `astro check` is now at 0 errors
- Removed unused dependencies: `@astrojs/sitemap` (replaced above) and `@headlessui/tailwindcss` (no references anywhere)

## Verification
- `npm run build` under the pinned Node 20: 144 pages, no network font fetch
- `astro check`: 0 errors, 0 warnings
- JSON-LD on 6 representative page types parses; correct schema per page type
- Lighthouse SEO 100 (homepage, post, demo) against `astro preview`
- `/nonexistent` → 404; sitemap/robots/rss all 200
- Regenerated demo OG image visually checked

## After deploy
1. Resubmit `https://rachel.fyi/sitemap.xml` in Search Console (URL changed from `/sitemap-index.xml`)
2. Run a post/work/demo URL through Google Rich Results Test
3. Re-scrape a demo page in LinkedIn Post Inspector to pick up the now-working share image

🤖 Generated with [Claude Code](https://claude.com/claude-code)