### PR TITLE
perf: fix blob CLS, font loading, render-blocking CSS/JS + SEO title/h1 fixes

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,6 +1,26 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 import react from "@astrojs/react";
+import { FontaineTransform } from "fontaine";
+
+/** Fontaine 0.8 declares its transform as `{ filter, handler }`, a hook form
+ *  Vite 5 silently skips — unwrap it to a plain function so it runs. */
+function fontainePlugin() {
+  const plugin = FontaineTransform.vite({
+    fallbacks: {
+      Lora: ["Georgia"],
+      "Zilla Slab": ["Georgia"],
+      "Archivo Black": ["Arial"],
+      "IBM Plex Mono": ["Courier New"],
+    },
+  }) as any;
+  const { handler } = plugin.transform;
+  plugin.transform = function (code: string, id: string) {
+    if (!/\.css(\?|$)/.test(id)) return;
+    return handler.call(this, code, id);
+  };
+  return plugin;
+}
 import remarkToc from "remark-toc";
 import { SITE } from "./src/config";
 import risoAnalogTheme, {
@@ -44,12 +64,21 @@ export default defineConfig({
       include: ["framer-motion"],
       exclude: ["@resvg/resvg-js"],
     },
+    plugins: [
+      // Metric-matched local fallback faces (size-adjust/ascent-override…)
+      // for each @font-face, so the swap to the web font doesn't reflow
+      // text — kills font CLS and the late LCP repaint of the first <p>.
+      fontainePlugin(),
+    ],
   },
   scopedStyleStrategy: "where",
   experimental: {
     contentLayer: true,
   },
   build: {
-    inlineStylesheets: "always",
+    // "always" inlined ~150 KB of CSS (incl. all @font-face) into every
+    // page head — nothing painted until it downloaded. "auto" keeps the
+    // shared sheet external and cacheable across pages.
+    inlineStylesheets: "auto",
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "^8.56.0",
         "eslint-plugin-astro": "^0.31.3",
+        "fontaine": "^0.8.0",
         "husky": "^8.0.3",
         "lint-staged": "^15.2.0",
         "postcss-import": "^16.1.0",
@@ -1482,6 +1483,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capsizecss/unpack": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
+      "integrity": "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@codemirror/language": {
@@ -3176,6 +3190,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -3207,9 +3232,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -8113,9 +8138,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -10404,6 +10429,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/constant-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -10623,6 +10655,20 @@
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
         "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -12349,6 +12395,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fontaine": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fontaine/-/fontaine-0.8.0.tgz",
+      "integrity": "sha512-eek1GbzOdWIj9FyQH/emqW1aEdfC3lYRCHepzwlFCm5T77fBSRSyNRKE6/antF1/B1M+SfJXVRQTY9GAr7lnDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@capsizecss/unpack": "^4.0.0",
+        "css-tree": "^3.1.0",
+        "magic-regexp": "^0.10.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3",
+        "ufo": "^1.6.1",
+        "unplugin": "^2.3.10"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/fontkitten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/foreground-child": {
@@ -16376,13 +16454,29 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "license": "MIT"
     },
-    "node_modules/magic-string": {
-      "version": "0.30.14",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.14.tgz",
-      "integrity": "sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==",
+    "node_modules/magic-regexp": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/magic-regexp/-/magic-regexp-0.10.0.tgz",
+      "integrity": "sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12",
+        "mlly": "^1.7.2",
+        "regexp-tree": "^0.1.27",
+        "type-level-regexp": "~0.1.17",
+        "ufo": "^1.5.4",
+        "unplugin": "^2.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/magicast": {
@@ -18669,6 +18763,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -20505,6 +20606,19 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/module-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
@@ -21233,6 +21347,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/periscopic": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
@@ -21367,6 +21488,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/popmotion": {
@@ -22411,6 +22544,16 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
     },
     "node_modules/rehype": {
       "version": "13.0.2",
@@ -26112,6 +26255,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/type-level-regexp": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.17.tgz",
+      "integrity": "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typedoc": {
       "version": "0.26.4",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.4.tgz",
@@ -26294,6 +26444,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -26644,6 +26801,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/unplugin/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -27766,6 +27952,13 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.56.0",
     "eslint-plugin-astro": "^0.31.3",
+    "fontaine": "^0.8.0",
     "husky": "^8.0.3",
     "lint-staged": "^15.2.0",
     "postcss-import": "^16.1.0",

--- a/src/components/PortfolioBoard.tsx
+++ b/src/components/PortfolioBoard.tsx
@@ -1,13 +1,10 @@
 import React, {
-  createContext,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { motion, useReducedMotion } from "framer-motion";
 import DymoLabel from "@components/riso/DymoLabel";
 import { NAV_LINK_STAGGER_S } from "@components/RisoNav";
 import {
@@ -94,12 +91,48 @@ const DEFAULT_SKILLS = [
  */
 const CONTENT_ENTRANCE_DELAY_S = NAV_LINK_STAGGER_S * 4 + 0.28;
 
-/** After this, board entrance delay drops to 0 so scroll-triggered items don’t wait. */
-const BOARD_DELAY_CLEAR_MS = Math.round(
-  (CONTENT_ENTRANCE_DELAY_S + 0.15) * 1000
-);
+type EntrancePhase =
+  /** SSR + pre-hydration: CSS entrance plays at load (content never hidden behind JS). */
+  | "auto"
+  /** Below the viewport at hydration: hidden, waiting on the observer. */
+  | "armed"
+  /** Observer fired: re-run the entrance now, without the nav-clearing delay. */
+  | "go";
 
-const BoardEntranceDelayContext = createContext(CONTENT_ENTRANCE_DELAY_S);
+/**
+ * Re-arms the load-time CSS entrance as a scroll-triggered one. Before
+ * hydration everything is visible (the CSS animation runs by itself); on
+ * mount, elements still fully below the viewport are hidden and revealed
+ * by an IntersectionObserver, matching the old framer `whileInView` feel.
+ */
+function useScrollEntrance(rootMargin: string) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [phase, setPhase] = useState<EntrancePhase>("auto");
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    // Anything at least partially on screen stays in the load-time flow —
+    // hiding it post-hydration would flash already-visible content.
+    if (el.getBoundingClientRect().top <= window.innerHeight) return;
+
+    setPhase("armed");
+    const io = new IntersectionObserver(
+      entries => {
+        if (entries.some(entry => entry.isIntersecting)) {
+          setPhase("go");
+          io.disconnect();
+        }
+      },
+      { rootMargin }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [rootMargin]);
+
+  return { ref, phase };
+}
 
 const BoardCard = React.memo(
   ({
@@ -142,8 +175,8 @@ const BoardCard = React.memo(
     const [z, setZ] = useState(10);
     const dragRef = useRef<HTMLDivElement | null>(null);
     const [isTouchDevice, setIsTouchDevice] = useState(false);
-    const prefersReducedMotion = useReducedMotion();
-    const boardEntranceDelayS = useContext(BoardEntranceDelayContext);
+    const { ref: entranceRef, phase: entrancePhase } =
+      useScrollEntrance("-10% 0px");
 
     useEffect(() => {
       setIsTouchDevice(
@@ -186,34 +219,22 @@ const BoardCard = React.memo(
     const currentRot = dragRot !== null ? dragRot : rot;
     const scale = isDragging ? 1.01 : 1;
 
-    const entranceVariants = useMemo(
-      () => ({
-        hidden: {
-          opacity: 0,
-          y: 30,
-          rotate: flat
-            ? 0
-            : rot +
-              (rotationSlug
-                ? boardCardEntranceExtraRotateDeg(rotationSlug)
-                : seededOffset(index * 31, 6)),
-          scale: 0.95,
-        },
-        visible: {
-          opacity: 1,
-          y: 0,
-          rotate: 0,
-          scale: 1,
-          transition: {
-            type: "spring" as const,
-            stiffness: 260,
-            damping: 25,
-            delay: boardEntranceDelayS + stagger * 0.08,
-          },
-        },
-      }),
-      [flat, rot, index, stagger, boardEntranceDelayS, rotationSlug]
+    const entranceRotDeg = useMemo(
+      () =>
+        flat
+          ? 0
+          : rot +
+            (rotationSlug
+              ? boardCardEntranceExtraRotateDeg(rotationSlug)
+              : seededOffset(index * 31, 6)),
+      [flat, rot, index, rotationSlug]
     );
+    // Scroll-triggered re-runs skip the nav-clearing delay (the old code
+    // cleared it with a timeout for the same reason).
+    const entranceDelayS =
+      entrancePhase === "go"
+        ? stagger * 0.08
+        : CONTENT_ENTRANCE_DELAY_S + stagger * 0.08;
 
     const shadowClass = isDragging
       ? "is-dragging"
@@ -243,38 +264,46 @@ const BoardCard = React.memo(
           willChange: isDragging ? "transform" : "auto",
         }}
       >
-        <motion.div
-          className={`board-card relative flex h-full flex-col select-none ${pin} ${shadowClass} ${className}`}
-          initial={prefersReducedMotion ? "visible" : "hidden"}
-          whileInView="visible"
-          viewport={{ once: true, margin: "-10% 0px" }}
-          variants={entranceVariants}
+        <div
+          ref={entranceRef}
+          className={`board-card relative flex h-full flex-col select-none ${pin} ${shadowClass} ${className} ${
+            entrancePhase === "armed" ? "board-enter-armed" : "board-enter"
+          }`}
+          style={
+            {
+              "--enter-rot": `${entranceRotDeg}deg`,
+              "--enter-delay": `${entranceDelayS}s`,
+            } as React.CSSProperties
+          }
         >
           {children}
-        </motion.div>
+        </div>
       </div>
     );
   }
 );
 
 const SectionDivider = ({ label, id }: { label: string; id: string }) => {
-  const prefersReducedMotion = useReducedMotion();
-  const boardEntranceDelayS = useContext(BoardEntranceDelayContext);
-  const delay = prefersReducedMotion ? 0 : boardEntranceDelayS;
+  const { ref, phase } = useScrollEntrance("-5% 0px");
   return (
-    <motion.div
-      className="mb-6 mt-16 flex items-center gap-3 py-2"
+    <div
+      ref={ref}
+      className={`mb-6 mt-16 flex items-center gap-3 py-2 ${
+        phase === "armed" ? "board-enter-armed" : "divider-enter"
+      }`}
       id={id}
-      initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: -20 }}
-      whileInView={{ opacity: 1, x: 0 }}
-      viewport={{ once: true, margin: "-5% 0px" }}
-      transition={{ duration: 0.4, ease: "easeOut", delay }}
+      style={
+        {
+          "--enter-delay":
+            phase === "go" ? "0s" : `${CONTENT_ENTRANCE_DELAY_S}s`,
+        } as React.CSSProperties
+      }
     >
       <h2 className="shrink-0">
         <DymoLabel text={label} size="section" isInteractive={false} />
       </h2>
       <span className="h-px flex-1 bg-[var(--black)]/15" aria-hidden="true" />
-    </motion.div>
+    </div>
   );
 };
 
@@ -309,274 +338,248 @@ export default function PortfolioBoard({
   work,
   demos,
 }: PortfolioBoardProps) {
-  const prefersReducedMotion = useReducedMotion();
-
-  const [boardEntranceDelayS, setBoardEntranceDelayS] = useState(() =>
-    prefersReducedMotion ? 0 : CONTENT_ENTRANCE_DELAY_S
-  );
-  useEffect(() => {
-    if (prefersReducedMotion) {
-      setBoardEntranceDelayS(0);
-      return;
-    }
-    const id = window.setTimeout(() => {
-      setBoardEntranceDelayS(0);
-    }, BOARD_DELAY_CLEAR_MS);
-    return () => window.clearTimeout(id);
-  }, [prefersReducedMotion]);
-
   return (
-    <BoardEntranceDelayContext.Provider value={boardEntranceDelayS}>
-      <div className="flex flex-col">
-        <section className="zone-hero relative" aria-label="Introduction">
+    <div className="flex flex-col">
+      <section className="zone-hero relative" aria-label="Introduction">
+        <BoardCard
+          index={0}
+          pin="tape-top tp-yellow"
+          className="hero-card"
+          stagger={0}
+        >
+          <div className="card h-full hero-card-inner border-[3px] border-[var(--black)] justify-center">
+            <h1 className="hero-headline mb-4 mt-0">{heroHeadline}</h1>
+            <p className="hero-body max-w-[480px]">{heroBody}</p>
+          </div>
+        </BoardCard>
+
+        <div className="hero-sidebar">
           <BoardCard
-            index={0}
-            pin="tape-top tp-yellow"
-            className="hero-card"
-            stagger={0}
+            index={1}
+            pin="pushpin pp-green"
+            className="skills-card"
+            wrapperClassName="max-sm:flex-1 max-sm:min-w-[140px]"
+            stagger={1}
           >
-            <div className="card h-full hero-card-inner border-[3px] border-[var(--black)] justify-center">
-              <h1 className="hero-headline mb-4 mt-0">{heroHeadline}</h1>
-              <p className="hero-body max-w-[480px]">{heroBody}</p>
+            <div
+              className="card flex flex-wrap content-center justify-center gap-[5px] p-4"
+              role="list"
+              aria-label="Technical skills"
+            >
+              {skills.map((tag, i) => {
+                const highlight = ["React", "a11y"].includes(tag)
+                  ? "tag-yellow"
+                  : tag === "UI Animation"
+                    ? "tag-pink"
+                    : "";
+                return (
+                  <span
+                    key={tag}
+                    role="listitem"
+                    className={`skill-tag inline-block ${highlight}`}
+                    style={{
+                      transform: `rotate(${seededOffset(i * 11, 1.5)}deg)`,
+                    }}
+                  >
+                    {tag}
+                  </span>
+                );
+              })}
             </div>
           </BoardCard>
 
-          <div className="hero-sidebar">
+          <BoardCard
+            index={2}
+            pin="pushpin pp-red"
+            className="quote-card"
+            wrapperClassName="max-sm:flex-1 max-sm:min-w-[140px]"
+            stagger={2}
+          >
+            <blockquote className="card m-0 flex min-h-[100px] items-center justify-center border-2 border-dashed border-[var(--black)] p-5">
+              <p className="quote-text">{quote}</p>
+            </blockquote>
+          </BoardCard>
+        </div>
+
+        <Swatch
+          color="var(--yellow)"
+          pattern="stripe"
+          index={0}
+          style={{
+            gridArea: "auto",
+            position: "absolute",
+            top: "-10px",
+            right: "40%",
+          }}
+        />
+      </section>
+
+      <SectionDivider label="Recent Posts" id="posts" />
+      <section
+        className="relative grid grid-cols-3 gap-8 max-lg:grid-cols-2 max-sm:grid-cols-1"
+        aria-label="Blog posts"
+      >
+        {posts.map((post, i) => {
+          const pins = [
+            "tape-c tc-pink",
+            "pushpin pp-yellow",
+            "pushpin pp-green",
+            "tape-top tp-blue",
+            "tape-c tc-yellow",
+            "pushpin pp-blue",
+          ];
+          return (
             <BoardCard
-              index={1}
-              pin="pushpin pp-green"
-              className="skills-card"
-              wrapperClassName="max-sm:flex-1 max-sm:min-w-[140px]"
-              stagger={1}
+              key={post.id}
+              index={i + 10}
+              flat
+              pin={pins[i % pins.length]}
+              className={`post-item ${i === 0 ? "featured-post-tape" : ""}`}
+              wrapperClassName={i === 0 ? "col-span-2 max-sm:col-span-1" : ""}
+              stagger={i}
             >
-              <div
-                className="card flex flex-wrap content-center justify-center gap-[5px] p-4"
-                role="list"
-                aria-label="Technical skills"
-              >
-                {skills.map((tag, i) => {
-                  const highlight = ["React", "a11y"].includes(tag)
-                    ? "tag-yellow"
-                    : tag === "UI Animation"
-                      ? "tag-pink"
-                      : "";
-                  return (
-                    <span
-                      key={tag}
-                      role="listitem"
-                      className={`skill-tag inline-block ${highlight}`}
-                      style={{
-                        transform: `rotate(${seededOffset(i * 11, 1.5)}deg)`,
-                      }}
-                    >
-                      {tag}
-                    </span>
-                  );
-                })}
-              </div>
-            </BoardCard>
-
-            <BoardCard
-              index={2}
-              pin="pushpin pp-red"
-              className="quote-card"
-              wrapperClassName="max-sm:flex-1 max-sm:min-w-[140px]"
-              stagger={2}
-            >
-              <blockquote className="card m-0 flex min-h-[100px] items-center justify-center border-2 border-dashed border-[var(--black)] p-5">
-                <p className="quote-text">{quote}</p>
-              </blockquote>
-            </BoardCard>
-          </div>
-
-          <Swatch
-            color="var(--yellow)"
-            pattern="stripe"
-            index={0}
-            style={{
-              gridArea: "auto",
-              position: "absolute",
-              top: "-10px",
-              right: "40%",
-            }}
-          />
-        </section>
-
-        <SectionDivider label="Recent Posts" id="posts" />
-        <section
-          className="relative grid grid-cols-3 gap-8 max-lg:grid-cols-2 max-sm:grid-cols-1"
-          aria-label="Blog posts"
-        >
-          {posts.map((post, i) => {
-            const pins = [
-              "tape-c tc-pink",
-              "pushpin pp-yellow",
-              "pushpin pp-green",
-              "tape-top tp-blue",
-              "tape-c tc-yellow",
-              "pushpin pp-blue",
-            ];
-            return (
-              <BoardCard
-                key={post.id}
-                index={i + 10}
-                flat
-                pin={pins[i % pins.length]}
-                className={`post-item ${i === 0 ? "featured-post-tape" : ""}`}
-                wrapperClassName={i === 0 ? "col-span-2 max-sm:col-span-1" : ""}
-                stagger={i}
-              >
-                <article className="card h-full flex flex-col">
-                  <time className="post-date" dateTime={post.dateTime}>
-                    {post.dateLabel}
-                  </time>
-                  <h3
-                    className={`post-title ${i === 0 ? "post-title-lg" : ""}`}
-                    style={{ viewTransitionName: post.slug }}
+              <article className="card h-full flex flex-col">
+                <time className="post-date" dateTime={post.dateTime}>
+                  {post.dateLabel}
+                </time>
+                <h3
+                  className={`post-title ${i === 0 ? "post-title-lg" : ""}`}
+                  style={{ viewTransitionName: post.slug }}
+                >
+                  <a
+                    href={post.href}
+                    className="hover:text-[var(--red)] transition-colors focus-visible:outline-none"
                   >
+                    {post.title}
+                  </a>
+                </h3>
+                {post.desc ? <p className="post-excerpt">{post.desc}</p> : null}
+                <div className="mt-auto flex items-center justify-between pt-4">
+                  <DymoLabel
+                    text={post.tag}
+                    size="section"
+                    color={post.tagColor}
+                    isInteractive={false}
+                  />
+                  <a href={post.href} className="card-link card-link-circle">
+                    <ArrowRightCircle className="h-[1.15rem] w-[1.15rem]" />
+                    <span className="sr-only">Read: {post.title}</span>
+                  </a>
+                </div>
+              </article>
+            </BoardCard>
+          );
+        })}
+      </section>
+
+      <div className="flex justify-center gap-4 py-2" aria-hidden="true">
+        <Swatch color="var(--red)" pattern="dot" index={3} />
+        <Swatch color="var(--blue)" pattern="dot" index={4} />
+        <Swatch color="var(--green)" pattern="stripe" index={5} />
+      </div>
+
+      <SectionDivider label="Featured Work" id="work" />
+      <section
+        className="relative grid grid-cols-3 gap-8 max-lg:grid-cols-2 max-sm:grid-cols-1"
+        aria-label="Selected work"
+      >
+        {work.map((w, i) => {
+          const pins = ["bclip", "tape-c tc-pink", "pushpin pp-yellow"];
+          return (
+            <BoardCard
+              key={w.id}
+              index={i + 20}
+              pin={pins[i % pins.length]}
+              className="work-item"
+              wrapperClassName={
+                i === work.length - 1
+                  ? "max-lg:col-span-2 max-sm:col-span-1"
+                  : ""
+              }
+              stagger={i}
+            >
+              <article className="card h-full flex flex-col">
+                <div className="flex flex-1 flex-col mb-4">
+                  <div className="work-label">{w.label}</div>
+                  <h3 className="work-name m-0">
                     <a
-                      href={post.href}
+                      href={w.href}
                       className="hover:text-[var(--red)] transition-colors focus-visible:outline-none"
                     >
-                      {post.title}
+                      {w.name}
                     </a>
                   </h3>
-                  {post.desc ? (
-                    <p className="post-excerpt">{post.desc}</p>
-                  ) : null}
-                  <div className="mt-auto flex items-center justify-between pt-4">
-                    <DymoLabel
-                      text={post.tag}
-                      size="section"
-                      color={post.tagColor}
-                      isInteractive={false}
-                    />
-                    <a href={post.href} className="card-link card-link-circle">
-                      <ArrowRightCircle className="h-[1.15rem] w-[1.15rem]" />
-                      <span className="sr-only">Read: {post.title}</span>
+                  <p className="work-desc !flex-none mt-1.5 mb-0 leading-relaxed">
+                    {w.desc}
+                  </p>
+                </div>
+                <a href={w.href} className="card-link self-start mt-auto !mb-1">
+                  <span aria-hidden="true">&rarr;</span> Case study
+                  <span className="sr-only">: {w.name}</span>
+                </a>
+              </article>
+            </BoardCard>
+          );
+        })}
+      </section>
+
+      <SectionDivider label="DEMOS" id="demos" />
+      <section
+        className="relative grid grid-cols-4 gap-8 max-lg:grid-cols-2"
+        aria-label="Interactive demos"
+      >
+        {demos.map((d, i) => {
+          const pins = [
+            "pushpin pp-red",
+            "tape-top tp-yellow",
+            "pushpin pp-blue",
+            "tape-top tp-green",
+          ];
+          return (
+            <BoardCard
+              key={d.id}
+              index={i + 30}
+              pin={pins[i % pins.length]}
+              className="demo-item"
+              stagger={i}
+            >
+              <article className="card h-full card-demo flex min-h-[130px] flex-col items-center text-center">
+                <div className="flex flex-1 w-full flex-col items-center pt-0 pb-3">
+                  <h3 className="demo-title m-0">
+                    <a
+                      href={d.href}
+                      className="hover:text-[var(--yellow)] transition-colors focus-visible:outline-none"
+                    >
+                      {d.title}
                     </a>
-                  </div>
-                </article>
-              </BoardCard>
-            );
-          })}
-        </section>
+                  </h3>
+                  <p className="demo-sub mt-auto pt-3 mb-0 leading-tight">
+                    {d.sub}
+                  </p>
+                </div>
+                <a href={d.href} className="card-link demo-link mt-auto !mb-1">
+                  <span aria-hidden="true">&rarr;</span> Launch
+                  <span className="sr-only">: {d.title} demo</span>
+                </a>
+              </article>
+            </BoardCard>
+          );
+        })}
+      </section>
 
-        <div className="flex justify-center gap-4 py-2" aria-hidden="true">
-          <Swatch color="var(--red)" pattern="dot" index={3} />
-          <Swatch color="var(--blue)" pattern="dot" index={4} />
-          <Swatch color="var(--green)" pattern="stripe" index={5} />
-        </div>
-
-        <SectionDivider label="Featured Work" id="work" />
-        <section
-          className="relative grid grid-cols-3 gap-8 max-lg:grid-cols-2 max-sm:grid-cols-1"
-          aria-label="Selected work"
-        >
-          {work.map((w, i) => {
-            const pins = ["bclip", "tape-c tc-pink", "pushpin pp-yellow"];
-            return (
-              <BoardCard
-                key={w.id}
-                index={i + 20}
-                pin={pins[i % pins.length]}
-                className="work-item"
-                wrapperClassName={
-                  i === work.length - 1
-                    ? "max-lg:col-span-2 max-sm:col-span-1"
-                    : ""
-                }
-                stagger={i}
-              >
-                <article className="card h-full flex flex-col">
-                  <div className="flex flex-1 flex-col mb-4">
-                    <div className="work-label">{w.label}</div>
-                    <h3 className="work-name m-0">
-                      <a
-                        href={w.href}
-                        className="hover:text-[var(--red)] transition-colors focus-visible:outline-none"
-                      >
-                        {w.name}
-                      </a>
-                    </h3>
-                    <p className="work-desc !flex-none mt-1.5 mb-0 leading-relaxed">
-                      {w.desc}
-                    </p>
-                  </div>
-                  <a
-                    href={w.href}
-                    className="card-link self-start mt-auto !mb-1"
-                  >
-                    <span aria-hidden="true">&rarr;</span> Case study
-                    <span className="sr-only">: {w.name}</span>
-                  </a>
-                </article>
-              </BoardCard>
-            );
-          })}
-        </section>
-
-        <SectionDivider label="DEMOS" id="demos" />
-        <section
-          className="relative grid grid-cols-4 gap-8 max-lg:grid-cols-2"
-          aria-label="Interactive demos"
-        >
-          {demos.map((d, i) => {
-            const pins = [
-              "pushpin pp-red",
-              "tape-top tp-yellow",
-              "pushpin pp-blue",
-              "tape-top tp-green",
-            ];
-            return (
-              <BoardCard
-                key={d.id}
-                index={i + 30}
-                pin={pins[i % pins.length]}
-                className="demo-item"
-                stagger={i}
-              >
-                <article className="card h-full card-demo flex min-h-[130px] flex-col items-center text-center">
-                  <div className="flex flex-1 w-full flex-col items-center pt-0 pb-3">
-                    <h3 className="demo-title m-0">
-                      <a
-                        href={d.href}
-                        className="hover:text-[var(--yellow)] transition-colors focus-visible:outline-none"
-                      >
-                        {d.title}
-                      </a>
-                    </h3>
-                    <p className="demo-sub mt-auto pt-3 mb-0 leading-tight">
-                      {d.sub}
-                    </p>
-                  </div>
-                  <a
-                    href={d.href}
-                    className="card-link demo-link mt-auto !mb-1"
-                  >
-                    <span aria-hidden="true">&rarr;</span> Launch
-                    <span className="sr-only">: {d.title} demo</span>
-                  </a>
-                </article>
-              </BoardCard>
-            );
-          })}
-        </section>
-
-        <div
-          className="flex flex-wrap justify-center gap-4 py-2"
-          aria-hidden="true"
-        >
-          <Swatch color="var(--pink)" pattern="stripe" index={6} />
-          <Swatch
-            color="var(--violet)"
-            pattern="dot"
-            index={7}
-            style={{ borderRadius: "50%" }}
-          />
-          <Swatch color="var(--orange)" pattern="dot" index={8} />
-        </div>
+      <div
+        className="flex flex-wrap justify-center gap-4 py-2"
+        aria-hidden="true"
+      >
+        <Swatch color="var(--pink)" pattern="stripe" index={6} />
+        <Swatch
+          color="var(--violet)"
+          pattern="dot"
+          index={7}
+          style={{ borderRadius: "50%" }}
+        />
+        <Swatch color="var(--orange)" pattern="dot" index={8} />
       </div>
-    </BoardEntranceDelayContext.Provider>
+    </div>
   );
 }

--- a/src/components/RisoBoardShell.astro
+++ b/src/components/RisoBoardShell.astro
@@ -43,8 +43,11 @@ const { animateNav = false, readingProgress = false } = Astro.props;
     </div>
 
     <div class="relative z-[110] flex min-h-0 flex-1 flex-col gap-8">
+      <!-- client:idle — the nav is fully server-rendered (active state from
+           activePath, entrance via CSS); hydration only adds the
+           astro:page-load active-link sync, so it can wait out the LCP. -->
       <RisoNav
-        client:load
+        client:idle
         activePath={Astro.url.pathname}
         siteTitle={SITE.title}
         animateEntrance={animateNav}

--- a/src/components/RisoNav.tsx
+++ b/src/components/RisoNav.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { useEffect, useState } from "react";
 import DymoLabel from "@components/riso/DymoLabel";
 
 const NAV_LINKS = [
@@ -38,24 +37,19 @@ export default function RisoNav({
 }: {
   activePath?: string;
   siteTitle: string;
-  /** Staggered spring entrance (homepage). */
+  /** Staggered entrance (homepage); pure CSS so it runs before hydration
+   *  and respects prefers-reduced-motion via the stylesheet. */
   animateEntrance?: boolean;
 }) {
   const currentPath = useActivePath(activePath);
-  const prefersReducedMotion = useReducedMotion();
-  const navSpring = { type: "spring" as const, stiffness: 380, damping: 28 };
-  const showNavMotion = animateEntrance && !prefersReducedMotion;
+  const entranceClass = animateEntrance ? "riso-nav-enter" : undefined;
 
   return (
-    <motion.nav
+    <nav
       className="relative z-50 flex w-full flex-wrap items-center justify-center gap-3 py-5 md:justify-between"
       aria-label="Main navigation"
     >
-      <motion.div
-        initial={showNavMotion ? { opacity: 0, y: -12 } : { opacity: 1, y: 0 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={navSpring}
-      >
+      <div className={entranceClass}>
         <div className="group relative inline-flex items-center">
           <DymoLabel
             text={siteTitle.toUpperCase().replace(/\s+/g, " ")}
@@ -73,22 +67,20 @@ export default function RisoNav({
             I&apos;m doing it live! 🚧
           </div>
         </div>
-      </motion.div>
+      </div>
       <ul
         className="flex list-none flex-wrap items-center justify-center gap-1.5 md:justify-start"
         role="list"
       >
         {NAV_LINKS.map(({ label, href }, i) => (
-          <motion.li
+          <li
             key={href}
-            initial={
-              showNavMotion ? { opacity: 0, y: -12 } : { opacity: 1, y: 0 }
+            className={entranceClass}
+            style={
+              animateEntrance
+                ? { animationDelay: `${NAV_LINK_STAGGER_S * (i + 1)}s` }
+                : undefined
             }
-            animate={{ opacity: 1, y: 0 }}
-            transition={{
-              ...navSpring,
-              delay: showNavMotion ? NAV_LINK_STAGGER_S * (i + 1) : 0,
-            }}
           >
             <DymoLabel
               text={label}
@@ -96,9 +88,9 @@ export default function RisoNav({
               href={href}
               isActive={isNavActive(currentPath, href)}
             />
-          </motion.li>
+          </li>
         ))}
       </ul>
-    </motion.nav>
+    </nav>
   );
 }

--- a/src/components/toc-scroll-behavior.js
+++ b/src/components/toc-scroll-behavior.js
@@ -53,29 +53,55 @@
       return header ? header.offsetHeight + 20 : 80;
     }
 
+    // Layout reads (offsetHeight/offsetTop/scrollHeight) are cached here and
+    // re-read only when geometry actually changes — doing them per scroll
+    // frame, interleaved with setActive's class writes, forced a reflow on
+    // every frame (28 ms flagged on mobile PSI).
+    let measurements = null;
+
+    function measure() {
+      const tops = [];
+      for (const item of items) {
+        const el = document.getElementById(item.id);
+        if (el) tops.push({ id: item.id, top: el.offsetTop });
+      }
+      measurements = {
+        offset: headerOffset(),
+        tops,
+        scrollHeight: document.documentElement.scrollHeight,
+        clientHeight: document.documentElement.clientHeight,
+      };
+    }
+
+    const invalidateMeasurements = () => {
+      measurements = null;
+    };
+    window.addEventListener("resize", invalidateMeasurements, {
+      passive: true,
+      signal,
+    });
+    // Content height changes after load (images, font swaps) move headings.
+    const resizeObserver = new ResizeObserver(invalidateMeasurements);
+    resizeObserver.observe(document.body);
+    signal.addEventListener("abort", () => resizeObserver.disconnect());
+
     function handleScroll() {
       if (isScrolling) return;
 
-      const offset = headerOffset();
+      if (!measurements) measure();
+      const { offset, tops, scrollHeight, clientHeight } = measurements;
       const scrollPosition = window.scrollY + offset;
       let currentSectionId = items[0].id;
 
-      for (const item of items) {
-        const el = document.getElementById(item.id);
-        if (!el) continue;
-        const offsetTop = el.offsetTop;
-        if (scrollPosition >= offsetTop) {
-          currentSectionId = item.id;
+      for (const t of tops) {
+        if (scrollPosition >= t.top) {
+          currentSectionId = t.id;
         } else {
           break;
         }
       }
 
-      const scrollHeight = document.documentElement.scrollHeight;
-      const scrollTop =
-        document.documentElement.scrollTop || document.body.scrollTop;
-      const clientHeight = document.documentElement.clientHeight;
-      if (scrollTop + clientHeight >= scrollHeight - 50) {
+      if (window.scrollY + clientHeight >= scrollHeight - 50) {
         currentSectionId = items[items.length - 1].id;
       }
 
@@ -85,7 +111,13 @@
     if (window.location.hash) {
       setActive(window.location.hash.slice(1));
     }
-    handleScroll();
+    // Defer the first measured pass past first paint: running it eagerly
+    // forces layout while the document is still parsing.
+    const idle = window.requestIdleCallback || (cb => window.setTimeout(cb, 1));
+    idle(() => {
+      if (generation !== runGeneration) return;
+      handleScroll();
+    });
 
     let ticking = false;
     window.addEventListener(

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,20 +2,29 @@
 import { LOCALE, SITE } from "@config";
 import "@styles/base.css";
 import "@styles/riso.css";
-import "@fontsource/archivo-black/400.css";
-import "@fontsource/lora/400.css";
-import "@fontsource/lora/400-italic.css";
-import "@fontsource/lora/700.css";
-import "@fontsource/lora/700-italic.css";
-import "@fontsource/zilla-slab/400.css";
-import "@fontsource/zilla-slab/500.css";
-import "@fontsource/zilla-slab/600.css";
-import "@fontsource/zilla-slab/700.css";
-import "@fontsource/zilla-slab/500-italic.css";
-import "@fontsource/zilla-slab/600-italic.css";
-import "@fontsource/ibm-plex-mono/400.css";
-import "@fontsource/ibm-plex-mono/700.css";
-import "@fontsource/ibm-plex-mono/400-italic.css";
+// Latin subsets only: the all-subset entries (`lora/400.css` etc.) inline 57
+// @font-face blocks (cyrillic, math, symbols…) into every page head. Content
+// is English; anything outside latin falls back to system fonts.
+import "@fontsource/archivo-black/latin-400.css";
+import "@fontsource/lora/latin-400.css";
+import "@fontsource/lora/latin-400-italic.css";
+import "@fontsource/lora/latin-700.css";
+import "@fontsource/lora/latin-700-italic.css";
+import "@fontsource/zilla-slab/latin-400.css";
+import "@fontsource/zilla-slab/latin-500.css";
+import "@fontsource/zilla-slab/latin-600.css";
+import "@fontsource/zilla-slab/latin-700.css";
+import "@fontsource/zilla-slab/latin-500-italic.css";
+import "@fontsource/zilla-slab/latin-600-italic.css";
+import "@fontsource/ibm-plex-mono/latin-400.css";
+import "@fontsource/ibm-plex-mono/latin-700.css";
+import "@fontsource/ibm-plex-mono/latin-400-italic.css";
+// Preloaded below: above-the-fold on every page (prose body = LCP element,
+// display headline, dymo-label mono). ?url resolves to the same hashed asset
+// the Fontsource CSS references.
+import loraLatin400Url from "@fontsource/lora/files/lora-latin-400-normal.woff2?url";
+import archivoBlackLatin400Url from "@fontsource/archivo-black/files/archivo-black-latin-400-normal.woff2?url";
+import plexMonoLatin700Url from "@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-700-normal.woff2?url";
 
 import { ViewTransitions } from "astro:transitions";
 import { getBreadcrumbItems } from "@utils/breadcrumbItems";
@@ -101,6 +110,19 @@ const serializeSchema = (schema: Record<string, unknown>) =>
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="canonical" href={canonicalURL} />
+    {
+      [loraLatin400Url, archivoBlackLatin400Url, plexMonoLatin700Url].map(
+        href => (
+          <link
+            rel="preload"
+            as="font"
+            type="font/woff2"
+            href={href}
+            crossorigin
+          />
+        )
+      )
+    }
     <meta name="generator" content={Astro.generator} />
 
     <!-- General Meta Tags -->
@@ -197,17 +219,32 @@ const serializeSchema = (schema: Record<string, unknown>) =>
       // target (#myBar from RisoBoardShell's readingProgress prop, .copy-code
       // buttons from rehype-copy-code), and both handlers query the live DOM
       // per event, so they never need re-binding or rerun guards.
+      // Scrollable range is cached and invalidated by the body
+      // ResizeObserver below: reading scrollHeight/clientHeight right after
+      // the previous frame's width write forces a reflow on every scroll
+      // frame otherwise.
+      let scrollRange = -1;
+      const invalidateScrollRange = () => {
+        scrollRange = -1;
+      };
+      new ResizeObserver(invalidateScrollRange).observe(document.body);
+      // Body height doesn't change on a long page when only the window
+      // resizes, but clientHeight does.
+      window.addEventListener("resize", invalidateScrollRange, {
+        passive: true,
+      });
       document.addEventListener(
         "scroll",
         () => {
           const bar = document.getElementById("myBar");
           if (!bar) return;
-          const height =
-            document.documentElement.scrollHeight -
-            document.documentElement.clientHeight;
-          const top =
-            document.documentElement.scrollTop || document.body.scrollTop;
-          bar.style.width = height > 0 ? `${(top / height) * 100}%` : "0%";
+          if (scrollRange < 0) {
+            scrollRange =
+              document.documentElement.scrollHeight -
+              document.documentElement.clientHeight;
+          }
+          bar.style.width =
+            scrollRange > 0 ? `${(window.scrollY / scrollRange) * 100}%` : "0%";
         },
         { passive: true }
       );

--- a/src/layouts/Posts.astro
+++ b/src/layouts/Posts.astro
@@ -18,6 +18,8 @@ const { portfolioPosts, pageSize } = Astro.props;
   description={`All blog posts by ${SITE.author} — frontend architecture, design systems, and production UI.`}
 >
   <Main pageTitle="Posts" showPageHeader={false} showBreadcrumbs={false}>
+    <!-- The board is purely visual (cards are h2s); pages need exactly one h1. -->
+    <h1 class="sr-only">Posts</h1>
     <PostsIndexBoard client:load posts={portfolioPosts} pageSize={pageSize} />
   </Main>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,10 @@ const portfolioDemos = homeDemosRaw.map(entry => ({
 }));
 ---
 
-<Layout structuredData={[websiteSchema(), personSchema()]}>
+<Layout
+  title={`${SITE.title} — Frontend Engineer`}
+  structuredData={[websiteSchema(), personSchema()]}
+>
   <RisoBoardShell animateNav>
     <main id="main-content" class="board-slot">
       <PortfolioBoard

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,8 +59,10 @@ const portfolioDemos = homeDemosRaw.map(entry => ({
 >
   <RisoBoardShell animateNav>
     <main id="main-content" class="board-slot">
+      <!-- client:idle — entrances are CSS-driven and content is SSR-visible,
+           so hydration (drag/hover/scroll-rearm) can wait out the LCP. -->
       <PortfolioBoard
-        client:load
+        client:idle
         heroHeadline="I turn design intent into production UI"
         heroBody={SITE.desc}
         quote="Available for senior frontend roles"

--- a/src/styles/riso.css
+++ b/src/styles/riso.css
@@ -53,8 +53,29 @@ nav .group:hover .dust-note {
   animation: dustWiggleHorizontal 4s infinite ease-in-out;
 }
 
+/* Nav entrance stagger (homepage): one-shot CSS replacement for the old
+   framer-motion spring, so the nav doesn't need the motion bundle. The
+   back-out bezier approximates the spring overshoot; `both` keeps items
+   hidden through their stagger delay. */
+@keyframes risoNavEnter {
+  from {
+    opacity: 0;
+    transform: translateY(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.riso-nav-enter {
+  animation: risoNavEnter 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
 @media (prefers-reduced-motion: reduce) {
   nav .group:hover .dust-note {
+    animation: none;
+  }
+  .riso-nav-enter {
     animation: none;
   }
 }
@@ -88,6 +109,9 @@ nav .group:hover .dust-note {
 }
 
 /* ── BLOBS ── */
+/* Anchors must not depend on .board height (px/svh only, never bottom/%):
+   the board grows as HTML streams in and fonts swap, and a height-relative
+   blob moves with every growth — 0.335 CLS on mobile PSI. */
 .blob {
   position: absolute;
   mix-blend-mode: multiply;
@@ -106,7 +130,7 @@ nav .group:hover .dust-note {
   width: 400px;
   height: 250px;
   background: var(--red);
-  top: 55%;
+  top: 55svh;
   left: 15%;
   border-radius: 40%;
 }
@@ -114,7 +138,8 @@ nav .group:hover .dust-note {
   width: 300px;
   height: 300px;
   background: var(--green);
-  bottom: 15%;
+  /* ≈ old `bottom: 15%` on a viewport-height board (homepage). */
+  top: calc(85svh - 300px);
   right: 5%;
 }
 
@@ -508,8 +533,11 @@ nav .group:hover .dust-note {
 .tp-green::before {
   background: var(--green);
   opacity: 0.75;
-  background-image:
-    linear-gradient(90deg, rgba(255, 255, 255, 0.3) 2px, transparent 2px),
+  background-image: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.3) 2px,
+      transparent 2px
+    ),
     linear-gradient(0deg, rgba(255, 255, 255, 0.3) 2px, transparent 2px);
   background-size: 8px 8px;
 }
@@ -651,7 +679,12 @@ nav .group:hover .dust-note {
   background-image: linear-gradient(180deg, #444 0%, #2a2a2a 40%, #111 100%);
 }
 .dymo.active {
-  background-image: linear-gradient(180deg, #ff5e56 0%, var(--red) 40%, #cc3d35 100%);
+  background-image: linear-gradient(
+    180deg,
+    #ff5e56 0%,
+    var(--red) 40%,
+    #cc3d35 100%
+  );
 }
 .dymo-lg {
   padding: 7px 14px 6px;
@@ -1095,7 +1128,9 @@ a.skip-to-content-board:focus {
   background-size: 100% 100%;
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
-  transition: background-image 0.2s, color 0.2s;
+  transition:
+    background-image 0.2s,
+    color 0.2s;
 }
 
 .prose.analog-prose a:hover {

--- a/src/styles/riso.css
+++ b/src/styles/riso.css
@@ -71,12 +71,60 @@ nav .group:hover .dust-note {
   animation: risoNavEnter 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 
+/* Board entrance (homepage cards + section dividers): CSS-first so the
+   SSR'd content paints without JS. framer-motion SSR'd its `initial`
+   opacity:0 and gated the reveal on hydrating the whole island chain —
+   the homepage was invisible for seconds on slow connections and LCP
+   fell to the grain texture. Cards below the viewport at hydration get
+   re-armed by useScrollEntrance (PortfolioBoard) to keep the
+   scroll-triggered reveal. */
+@keyframes boardCardEnter {
+  from {
+    opacity: 0;
+    transform: translateY(30px) scale(0.95) rotate(var(--enter-rot, 0deg));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1) rotate(0deg);
+  }
+}
+.board-enter {
+  animation: boardCardEnter 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: var(--enter-delay, 0s);
+}
+@keyframes dividerEnter {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.divider-enter {
+  animation: dividerEnter 0.4s ease-out both;
+  animation-delay: var(--enter-delay, 0s);
+}
+/* Hidden while waiting for the IntersectionObserver to fire; only ever
+   applied after hydration, to elements fully below the viewport. */
+.board-enter-armed {
+  opacity: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   nav .group:hover .dust-note {
     animation: none;
   }
   .riso-nav-enter {
     animation: none;
+  }
+  .board-enter,
+  .divider-enter {
+    animation: none;
+  }
+  .board-enter-armed {
+    opacity: 1;
   }
 }
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -155,11 +155,26 @@ module.exports = {
           '"Segoe UI Symbol"',
           '"Noto Color Emoji"',
         ],
-        serif: ["Zilla Slab", "Georgia", "serif"],
-        display: ["Archivo Black", "ui-sans-serif", "system-ui", "sans-serif"],
-        heading: ["Zilla Slab", "Georgia", "serif"],
-        body: ["Lora", "Georgia", "ui-serif", "serif"],
-        mono: ["IBM Plex Mono", "ui-monospace", "SFMono-Regular", "monospace"],
+        /* "<Family> fallback" faces are metric-matched local fonts generated
+         * by fontaine (astro.config.ts) — they hold the web font's geometry
+         * before it loads, so the swap doesn't shift text. */
+        serif: ["Zilla Slab", "Zilla Slab fallback", "Georgia", "serif"],
+        display: [
+          "Archivo Black",
+          "Archivo Black fallback",
+          "ui-sans-serif",
+          "system-ui",
+          "sans-serif",
+        ],
+        heading: ["Zilla Slab", "Zilla Slab fallback", "Georgia", "serif"],
+        body: ["Lora", "Lora fallback", "Georgia", "ui-serif", "serif"],
+        mono: [
+          "IBM Plex Mono",
+          "IBM Plex Mono fallback",
+          "ui-monospace",
+          "SFMono-Regular",
+          "monospace",
+        ],
       },
 
       /* Modular scale — major third (1.25); rem values harmonize display vs body */
@@ -193,7 +208,7 @@ module.exports = {
             maxWidth: 'var(--max-3xl)',
             lineHeight: '1.65',
             fontSize: '1rem',
-            fontFamily: "'Lora', Georgia, ui-serif, serif",
+            fontFamily: "'Lora', 'Lora fallback', Georgia, ui-serif, serif",
             color: 'rgb(var(--color-text-base))',
             'a:hover': {
               color: 'rgb(var(--color-accent))',
@@ -211,7 +226,7 @@ module.exports = {
             h1: {
               fontWeight: '400',
               letterSpacing: '-0.02em',
-              fontFamily: 'Archivo Black, ui-sans-serif, system-ui, sans-serif',
+              fontFamily: 'Archivo Black, Archivo Black fallback, ui-sans-serif, system-ui, sans-serif',
               marginTop: '1.25em',
               marginBottom: '0.5em',
             },
@@ -221,7 +236,7 @@ module.exports = {
             h2: {
               fontWeight: '600',
               letterSpacing: '-0.01em',
-              fontFamily: 'Zilla Slab, Georgia, serif',
+              fontFamily: 'Zilla Slab, Zilla Slab fallback, Georgia, serif',
               marginTop: '1.25em',
               marginBottom: '0.5em',
             },
@@ -231,7 +246,7 @@ module.exports = {
             h3: {
               fontWeight: '600',
               letterSpacing: '-0.01em',
-              fontFamily: 'Zilla Slab, Georgia, serif',
+              fontFamily: 'Zilla Slab, Zilla Slab fallback, Georgia, serif',
               marginTop: '1.25em',
               marginBottom: '0.5em',
             },
@@ -241,7 +256,7 @@ module.exports = {
             h4: {
               fontWeight: '600',
               letterSpacing: '-0.01em',
-              fontFamily: 'Zilla Slab, Georgia, serif',
+              fontFamily: 'Zilla Slab, Zilla Slab fallback, Georgia, serif',
               marginTop: '1.25em',
               marginBottom: '0.5em',
             },
@@ -251,7 +266,7 @@ module.exports = {
             h5: {
               fontWeight: '600',
               letterSpacing: '-0.01em',
-              fontFamily: 'Zilla Slab, Georgia, serif',
+              fontFamily: 'Zilla Slab, Zilla Slab fallback, Georgia, serif',
               marginTop: '1.25em',
               marginBottom: '0.5em',
             },
@@ -261,7 +276,7 @@ module.exports = {
             h6: {
               fontWeight: '600',
               letterSpacing: '-0.01em',
-              fontFamily: 'Zilla Slab, Georgia, serif',
+              fontFamily: 'Zilla Slab, Zilla Slab fallback, Georgia, serif',
               marginTop: '1.25em',
               marginBottom: '0.5em',
             },
@@ -269,7 +284,7 @@ module.exports = {
               marginTop: '0',
             },
             code: {
-              fontFamily: 'IBM Plex Mono, monospace',
+              fontFamily: 'IBM Plex Mono, IBM Plex Mono fallback, monospace',
               fontSize: '0.9em',
               backgroundColor: 'rgba(var(--color-text-base), 0.05)',
               padding: '0.2em 0.4em',
@@ -277,7 +292,7 @@ module.exports = {
               fontWeight: '400',
             },
             pre: {
-              fontFamily: 'IBM Plex Mono, monospace',
+              fontFamily: 'IBM Plex Mono, IBM Plex Mono fallback, monospace',
               fontSize: '0.9em',
             },
             strong: {
@@ -296,7 +311,7 @@ module.exports = {
               fontSize: '0.95rem',
             },
             'blockquote > p, blockquote > ul > li, blockquote > ol > li': {
-              fontFamily: 'IBM Plex Mono, monospace',
+              fontFamily: 'IBM Plex Mono, IBM Plex Mono fallback, monospace',
             },
 
             'hr': {


### PR DESCRIPTION
## Why

Mobile PageSpeed on post pages dropped to **70** after the SEO overhaul: CLS 0.345 (poor), LCP 3.7s (poor). Desktop confirmed CLS as cross-device/structural (0.169). The homepage audit (mobile 88) then surfaced a separate structural issue. Root causes:

1. **`.blob-3`/`.blob-4` anchored to the board's height** (`top: 55%`, `bottom: 15%`). The board grows as HTML streams in and fonts swap, so the blobs moved on every growth — 0.335 of the mobile CLS came from a single static (not animated!) blob.
2. **`inlineStylesheets: "always"`** put ~150 KB of CSS — including 57 `@font-face` blocks with every unicode subset — in the head of every page. Post HTML was 201 KB; nothing painted until it downloaded.
3. **Web-font swaps without metric-matched fallbacks** shifted text and re-stamped the LCP paint of the first paragraph.
4. **framer-motion + react-dom at load priority on every page** via `RisoNav client:load`, for an entrance animation that only runs on the homepage.
5. **TOC scroll-spy forced reflows** — `offsetTop` loop per scroll frame, eager first run mid-parse (28 ms flagged).
6. **Homepage SSR'd invisible**: framer-motion serialized its entrance `initial` state, so the built HTML had 21 elements at `opacity:0` — including the hero card — revealed only after an 86 KB gz island chain hydrated. LCP fell to the `.grain` texture; Speed Index 3.1s.

## What changed

**Post pages / sitewide (commit 1)**
- Blobs anchored in viewport units (`top: 55svh` / `calc(85svh - 300px)`) — position no longer depends on document height
- Latin-only Fontsource subsets (57 → 28 `@font-face`) + preload for the three above-the-fold faces (Lora 400 = LCP paragraph, Archivo Black, Plex Mono 700 — the exact file PSI flagged)
- [fontaine](https://github.com/unjs/fontaine)-generated metric-matched local fallback faces wired into every Tailwind font stack. Note: fontaine 0.8's `{filter, handler}` transform hook is silently skipped by Vite 5, so `astro.config.ts` unwraps it to a plain function
- `inlineStylesheets: "auto"` — post HTML **201 KB → 56 KB**, CSS now one external cacheable file
- RisoNav: framer-motion replaced with a CSS keyframe stagger, hydrated `client:idle`. Post pages load zero motion code
- TOC scroll-spy + reading-progress bar cache their layout reads; first spy pass deferred past first paint

**SEO (commit 2)**
- Homepage `<title>` now "Rachel Cantor — Frontend Engineer" (was bare name); `/posts` gets its missing `<h1>` (sr-only — the board art is the visual header)

**Homepage (commit 3)**
- BoardCard/SectionDivider entrances are CSS keyframes (`--enter-rot`/`--enter-delay` vars); SSR output is fully visible and animates at first paint with the same stagger/delay design
- `useScrollEntrance` (IntersectionObserver) re-arms the entrance post-hydration for elements still below the viewport — scroll-triggered reveal preserved, and pre-hydration scrolling shows content instead of blank cards
- framer-motion removed from PortfolioBoard (demos keep it); homepage JS **10 files / 86 KB gz → 8 files / 52.5 KB gz**
- PortfolioBoard hydrates `client:idle` — only drag/hover/scroll-rearm depend on JS now

## Verification (local build)

- Post page HTML: 201,070 → 56,311 bytes; zero inline `@font-face`; 3 font preloads with hashed URLs matching the CSS
- Built CSS contains 14 `* fallback` faces and rewritten stacks (`font-family:Lora,Lora fallback,Georgia,…`)
- Homepage HTML: zero SSR'd `opacity:0` content (was 21 elements); hero card visible; no motion chunk in the island graph
- Post page references no motion chunk; `/posts` has exactly one `<h1>`; `tsc` clean

Real-world check: re-run mobile PSI on both pages after deploy — expected post-page CLS ≈ 0 / LCP < 3s, homepage LCP should move from the grain texture to the hero text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)