### PR TITLE
perf: font-display optional for Lora (post-page LCP)

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -28,6 +28,25 @@ function fontainePlugin() {
   };
   return plugin;
 }
+
+/** Fontsource hardcodes font-display: swap. Body copy (Lora) is the post
+ *  pages' LCP element, and with swap the paragraph repaints when the webfont
+ *  lands — Chrome re-stamps LCP at that repaint (PSI: 1,410ms render delay
+ *  on slow 4G, the whole remaining post LCP gap). `optional` commits to the
+ *  metric-matched Georgia fallback when Lora misses the ~100ms block window,
+ *  so the first paint is the only paint and LCP ≈ FCP. All four Lora faces
+ *  flip together — a partial flip would mix fallback body text with real
+ *  Lora bold/italic mid-paragraph. Display/mono faces keep swap so the
+ *  stamped headlines still upgrade. */
+function loraFontDisplayOptional() {
+  return {
+    name: "lora-font-display-optional",
+    transform(code: string, id: string) {
+      if (!id.includes("@fontsource/lora")) return;
+      return code.replace(/font-display:\s*swap/g, "font-display: optional");
+    },
+  };
+}
 /** Inline each page's used CSS and load the stylesheets async (media swap).
  *  The render-blocking shared sheet was the whole LCP render delay on mobile
  *  (~1.1s est. by Lighthouse): nothing painted until ~20KB gz of CSS arrived.
@@ -139,6 +158,7 @@ export default defineConfig({
       // for each @font-face, so the swap to the web font doesn't reflow
       // text — kills font CLS and the late LCP repaint of the first <p>.
       fontainePlugin(),
+      loraFontDisplayOptional(),
     ],
   },
   scopedStyleStrategy: "where",


### PR DESCRIPTION
## Why

With render-blocking CSS gone (#12), the post pages' mobile LCP element is now the first article paragraph, still at LCP 3.0s / 1,410ms render delay. The gate is the font swap, not loading order: `lora-latin-400-normal.woff2` is already the *first* preload, but on slow 4G it can't beat first paint, so the paragraph paints in the metric-matched Georgia fallback and then repaints when Lora lands — and Chrome re-stamps LCP at that repaint.

## What

A small Vite transform flips `font-display: swap` → `optional` for the `@fontsource/lora` faces only (Fontsource hardcodes swap). With `optional`, when Lora misses the ~100ms block window the page commits to the fontaine metric-matched fallback and never repaints — first paint is the only paint, so LCP ≈ FCP (~2.0s instead of 3.0s expected on PSI mobile).

- All four Lora faces (400/400i/700/700i) flip together — a partial flip would mix fallback body text with real-Lora bold/italic mid-paragraph.
- Archivo Black / Zilla Slab / IBM Plex Mono keep `swap`, so the stamped headlines and labels still upgrade visibly.
- Trade-off (deliberate, discussed): slow-connection first-time readers get the whole article in adjusted Georgia; repeat navigations get Lora from cache. Fast connections make the block window (font is preloaded) and see Lora from the first frame.

## Verification

- Built CSS + inlined critical CSS both show `font-display: optional` on exactly the 4 Lora faces, `swap` on the other 10; fontaine fallback overrides still inlined on every page.
- Local Lighthouse (mobile post, built dist): CLS 0, observed element render delay 107ms. Local runs can't show the LCP win — on a fast network Lora wins the block window so the trace still paints in Lora; the real measurement is PSI mobile on a post after deploy.
- Visual parity screenshot: identical rendering on fast load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)