### PR TITLE
chore: apply deferred review cleanups from PR #15

### DIFF
--- a/src/components/ArrowRightCircle.tsx
+++ b/src/components/ArrowRightCircle.tsx
@@ -1,0 +1,25 @@
+/** Chunky chevron right, centered for use inside the circular card-link
+ *  button on board cards (homepage + /posts). */
+export default function ArrowRightCircle({
+  className,
+  ...props
+}: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M10.25 8.25 14 12l-3.75 3.75"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/PortfolioBoard.tsx
+++ b/src/components/PortfolioBoard.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import ArrowRightCircle from "@components/ArrowRightCircle";
 import DymoLabel from "@components/riso/DymoLabel";
 import {
   NAV_ENTER_DURATION_S,
@@ -18,29 +19,6 @@ import {
 import { seededOffset } from "@utils/seededOffset";
 
 export type TagColor = "red" | "blue" | "green";
-
-const ArrowRightCircle = ({
-  className,
-  ...props
-}: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    aria-hidden="true"
-    className={className}
-    {...props}
-  >
-    {/* Chunky chevron right, centered for use inside the circular button */}
-    <path
-      d="M10.25 8.25 14 12l-3.75 3.75"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
 
 export interface PortfolioPost {
   id: string;
@@ -284,9 +262,7 @@ const BoardCard = React.memo(
           transform: `translate(${offset.x}px, ${offset.y}px) rotate(${currentRot}deg) scale(${scale})`,
           zIndex: isDragging ? 9999 : z,
           cursor: isTouchDevice ? "default" : isDragging ? "grabbing" : "grab",
-          transition: isDragging
-            ? "none"
-            : "transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)",
+          transition: isDragging ? "none" : "transform 0.3s var(--ease-spring)",
           touchAction: "auto",
           willChange: isDragging ? "transform" : "auto",
         }}

--- a/src/components/RisoNav.tsx
+++ b/src/components/RisoNav.tsx
@@ -66,7 +66,7 @@ export default function RisoNav({
             className="after:absolute after:-inset-4 after:content-['']"
           />
           <div
-            className="dust-note pointer-events-none absolute left-[calc(100%+12px)] top-1/2 z-[100] hidden min-w-[200px] max-w-[300px] -translate-x-[10px] -translate-y-1/2 rotate-[3deg] border border-dashed border-black/20 bg-[var(--yellow)] px-[10px] py-1.5 text-center font-mono text-sm font-bold uppercase leading-tight tracking-wide text-[var(--black)] opacity-0 shadow-[2px_3px_6px_rgba(0,0,0,0.2)] transition-[opacity_0.2s_ease,transform_0.3s_cubic-bezier(0.34,1.56,0.64,1)] [clip-path:polygon(0%_0%,100%_0%,98%_100%,2%_95%)] group-hover:-translate-y-1/2 group-hover:translate-x-[5px] group-hover:-rotate-2 group-hover:opacity-100 motion-reduce:transition-[opacity_0.2s_ease,transform_0.2s_ease] transform-gpu backface-hidden md:block"
+            className="dust-note pointer-events-none absolute left-[calc(100%+12px)] top-1/2 z-[100] hidden min-w-[200px] max-w-[300px] -translate-x-[10px] -translate-y-1/2 rotate-[3deg] border border-dashed border-black/20 bg-[var(--yellow)] px-[10px] py-1.5 text-center font-mono text-sm font-bold uppercase leading-tight tracking-wide text-[var(--black)] opacity-0 shadow-[2px_3px_6px_rgba(0,0,0,0.2)] transition-[opacity_0.2s_ease,transform_0.3s_var(--ease-spring)] [clip-path:polygon(0%_0%,100%_0%,98%_100%,2%_95%)] group-hover:-translate-y-1/2 group-hover:translate-x-[5px] group-hover:-rotate-2 group-hover:opacity-100 motion-reduce:transition-[opacity_0.2s_ease,transform_0.2s_ease] transform-gpu backface-hidden md:block"
             aria-hidden="true"
           >
             Pardon the dust, <br />

--- a/src/components/riso/PostPagination.tsx
+++ b/src/components/riso/PostPagination.tsx
@@ -54,7 +54,7 @@ export default function PostPagination({
       display: flex;
       flex-direction: column;
       justify-content: center;
-      transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), z-index 0s 0.3s;
+      transition: transform 0.3s var(--ease-spring), z-index 0s 0.3s;
 
       /* Ruled index card top line using the base ink color */
       border-top: 2px solid rgb(var(--color-text-base));
@@ -83,7 +83,7 @@ export default function PostPagination({
       /* Cards "slide out" from under the paper on hover */
       transform: translateY(16px) rotate(0deg);
       z-index: 15; /* Lift above the paper edge temporarily */
-      transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), z-index 0s;
+      transition: transform 0.3s var(--ease-spring), z-index 0s;
     }
 
     /* ── CARD CONTENT ── */

--- a/src/components/riso/PostsIndexBoard.tsx
+++ b/src/components/riso/PostsIndexBoard.tsx
@@ -1,29 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import ArrowRightCircle from "@components/ArrowRightCircle";
 import DymoLabel from "@components/riso/DymoLabel";
+import { usePrefersReducedMotion } from "@utils/usePrefersReducedMotion";
 import type { PortfolioPost } from "@components/PortfolioBoard";
-
-const ArrowRightCircle = ({
-  className,
-  ...props
-}: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    aria-hidden="true"
-    className={className}
-    {...props}
-  >
-    {/* Chunky chevron right, centered for use inside the circular button */}
-    <path
-      d="M10.25 8.25 14 12l-3.75 3.75"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
 
 /** Seconds between each card's entrance — clearer than PortfolioBoard's 0.08s step. */
 const STAGGER_STEP_S = 0.14;
@@ -48,22 +27,7 @@ const PULL_CORD_THRESHOLD_PX = 28;
 /** Pulls above this offset suppress the button click (avoids duplicate after a drag). */
 const PULL_DRAG_SUPPRESS_CLICK_PX = 10;
 /** Snap-back duration for the cord stretch (matches riso.css easing). */
-const PULL_SNAP_TRANSITION = "height 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)";
-
-/** matchMedia-backed replacement for framer's useReducedMotion (the entrance
- *  animations are CSS and gate themselves; this only drives the pull cord's
- *  snap-back suppression). */
-function usePrefersReducedMotion() {
-  const [reduced, setReduced] = useState(false);
-  useEffect(() => {
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduced(mq.matches);
-    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
-  }, []);
-  return reduced;
-}
+const PULL_SNAP_TRANSITION = "height 0.35s var(--ease-spring)";
 
 function DraggableCard({
   index,
@@ -175,6 +139,14 @@ function PullMoreCord({
   onLoadMore: () => void;
 }) {
   const reduced = prefersReducedMotion;
+  /** The cord's pull/click handlers are React-bound, so pre-hydration (and
+   *  with JS off) the SSR'd cord is a dead control — keep it hidden until
+   *  mount so it never invites an interaction that does nothing. Older
+   *  posts stay reachable without JS via the paginated tag pages. */
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
   const [stretchPx, setStretchPx] = useState(0);
   const [pullDragActive, setPullDragActive] = useState(false);
   const [snapping, setSnapping] = useState(false);
@@ -312,7 +284,9 @@ function PullMoreCord({
 
   return (
     <div
-      className={`pull-container ${reduced ? "pull-container--no-motion" : ""}`}
+      className={`pull-container${hydrated ? " pull-container--ready" : ""}${
+        reduced ? " pull-container--no-motion" : ""
+      }`}
     >
       <div
         className={stackClass}

--- a/src/styles/riso-posts-index.css
+++ b/src/styles/riso-posts-index.css
@@ -84,7 +84,7 @@
         var(--bottom-pad)
     )
   );
-  transition: height 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: height 0.5s var(--ease-spring);
 }
 
 .posts-index-board--complete {
@@ -92,25 +92,28 @@
 }
 
 /* Stacked band: one centered column; cards shrink to fit narrow boards.
- * Media-query fallback first (board ≈ viewport − 80px page chrome, kept
- * conservatively low so it never disagrees with the container query), then
- * the container queries re-assert BOTH bands so supporting browsers always
- * use the true board width. */
-@media (max-width: 930px) {
-  .posts-index-board {
-    --card-w: min(360px, calc(100% - 16px));
-    --row-step: 360px;
-    --base-y: 140px;
-    --twine-top: 66px;
-    --est-h: 350px;
-    --card-left-left: calc(50% - var(--card-w) / 2);
-    --card-left-right: calc(50% - var(--card-w) / 2);
-    --rss-left: calc(50% + var(--card-w) / 2);
+ * Each band is declared once per path: container queries for supporting
+ * browsers; viewport approximations (board ≈ viewport − ~100px page chrome,
+ * thresholds kept low so any mismatch resolves to stacked, which always
+ * fits) inside @supports-not for the rest. The two paths can never both
+ * apply, so they cannot drift apart. */
+@supports not (container-type: inline-size) {
+  @media (max-width: 930px) {
+    .posts-index-board {
+      --card-w: min(360px, calc(100% - 16px));
+      --row-step: 360px;
+      --base-y: 140px;
+      --twine-top: 66px;
+      --est-h: 350px;
+      --card-left-left: calc(50% - var(--card-w) / 2);
+      --card-left-right: calc(50% - var(--card-w) / 2);
+      --rss-left: calc(50% + var(--card-w) / 2);
+    }
   }
-}
-@media (max-width: 710px) {
-  .posts-index-board {
-    --bottom-pad: 300px;
+  @media (max-width: 710px) {
+    .posts-index-board {
+      --bottom-pad: 300px;
+    }
   }
 }
 @container (width < 854px) {
@@ -125,26 +128,9 @@
     --rss-left: calc(50% + var(--card-w) / 2);
   }
 }
-@container (width >= 854px) {
-  .posts-index-board {
-    --card-w: 360px;
-    --row-step: 270px;
-    --base-y: 104px;
-    --twine-top: 52px;
-    --est-h: 320px;
-    --card-left-left: max(8px, calc(50% - 407px));
-    --card-left-right: min(calc(50% + 47px), calc(100% - 368px));
-    --rss-left: min(calc(50% + 407px), calc(100% - 8px));
-  }
-}
 @container (width < 640px) {
   .posts-index-board {
     --bottom-pad: 300px;
-  }
-}
-@container (width >= 640px) {
-  .posts-index-board {
-    --bottom-pad: 260px;
   }
 }
 
@@ -158,9 +144,9 @@
   top: calc(var(--base-y) + var(--i, 0) * var(--row-step));
   left: var(--card-left-left);
   transition:
-    left 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
-    top 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
-    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    left 0.5s var(--ease-spring),
+    top 0.5s var(--ease-spring),
+    transform 0.3s var(--ease-spring);
 }
 .posts-card--right {
   left: var(--card-left-right);
@@ -194,7 +180,7 @@
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   z-index: 1;
   border-radius: 2px;
-  transition: height 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: height 0.5s var(--ease-spring);
 }
 
 /* Manila shipping tag — upper right; pushpin head (::before) sits in punched hole; ring (::after). */
@@ -235,7 +221,7 @@
     #e6d5b8 calc(var(--rss-hole-r) + 0.5px)
   );
   filter: drop-shadow(2px 3px 5px rgba(0, 0, 0, 0.28));
-  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: transform 0.35s var(--ease-spring);
 }
 
 /* Pushpin head — matches .pushpin look, centered on hole */
@@ -387,9 +373,16 @@
   flex-direction: column;
   align-items: center;
   transform: translateX(-50%);
-  transition: top 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: top 0.5s var(--ease-spring);
   /* Let the cord pull gesture win over page scroll / touch gestures (all pointer types). */
   touch-action: none;
+  /* Hidden until hydration adds --ready (PullMoreCord): the handlers are
+     React-bound, so the SSR'd cord is a dead control until then — and
+     forever with JS off. Space is still reserved (twine math unchanged). */
+  visibility: hidden;
+}
+.pull-container--ready {
+  visibility: visible;
 }
 
 /* Inner stack: knot + CTA — bounce only affects Y so pull-drag translateY can compose. */

--- a/src/styles/riso.css
+++ b/src/styles/riso.css
@@ -36,6 +36,11 @@
   --riso-leading-normal: 1.5;
   --riso-leading-relaxed: 1.55;
   --riso-leading-loose: 1.6;
+
+  /* House overshoot curve — the springy back-out used by every board
+     entrance, card transition, and cord snap. TSX inline styles reference
+     it via var(--ease-spring) too; never paste the literal. */
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 /* “Pardon the dust” tape wiggle — keyframes + group-hover (see RisoNav) */
@@ -73,7 +78,7 @@ nav .group:hover .dust-note {
 .riso-nav-enter {
   /* Duration mirrored by NAV_ENTER_DURATION_S in RisoNav.tsx (the board
      entrance delay is derived from it) — change both together. */
-  animation: risoNavEnter 0.28s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+  animation: risoNavEnter 0.28s var(--ease-spring) backwards;
 }
 
 /* Board entrance (homepage cards + section dividers): CSS-first so the
@@ -94,7 +99,7 @@ nav .group:hover .dust-note {
   }
 }
 .board-enter {
-  animation: boardCardEnter 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+  animation: boardCardEnter 0.55s var(--ease-spring) backwards;
   animation-delay: var(--enter-delay, 0s);
 }
 @keyframes dividerEnter {

--- a/src/utils/usePrefersReducedMotion.ts
+++ b/src/utils/usePrefersReducedMotion.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+/** Live `prefers-reduced-motion` value; `false` until mounted (SSR-safe).
+ *  Prefer gating motion in CSS media queries — reach for this only when JS
+ *  behavior itself must branch (e.g. suppressing a programmatic snap-back). */
+export function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    // Safari ≤13 MediaQueryList lacks addEventListener; use the legacy API
+    // there instead of throwing — an uncaught effect error unmounts the
+    // whole island.
+    if (typeof mq.addEventListener === "function") {
+      mq.addEventListener("change", onChange);
+      return () => mq.removeEventListener("change", onChange);
+    }
+    mq.addListener(onChange);
+    return () => mq.removeListener(onChange);
+  }, []);
+  return reduced;
+}


### PR DESCRIPTION
## What

The five mechanical items deferred from the PR #15 review (inline comments there have the full rationale):

1. **`ArrowRightCircle`** — extracted to `src/components/ArrowRightCircle.tsx`; it was byte-identical in both boards, down to the JSX comment.
2. **`usePrefersReducedMotion`** — extracted to `src/utils/usePrefersReducedMotion.ts` with a legacy `addListener` fallback: `MediaQueryList.addEventListener` throws on Safari ≤13, and an uncaught effect error unmounts the whole island (blanking the SSR-rendered board).
3. **`--ease-spring` token** — the house overshoot curve (`cubic-bezier(0.34, 1.56, 0.64, 1)`) was 14 literals across 6 files, flagged in three consecutive reviews. Now one `:root` token; CSS rules and TSX inline styles both reference `var(--ease-spring)`. One literal remains: the token definition.
4. **Band declarations once per path** — the viewport-approximation fallbacks for the /posts board geometry now live inside `@supports not (container-type: inline-size)`, which makes the two `@container (width >= …)` re-assert blocks unnecessary (equivalence verified during review). The container-query path and the fallback path can no longer drift apart.
5. **Pull-cord dead window** — the cord is `visibility: hidden` until hydration adds `pull-container--ready`. Pre-hydration (and with JS off) it was a visible, bouncing, completely inert control. Older posts remain reachable without JS via the statically paginated tag pages.

## Verification (local build + headless Chromium)

- One bezier literal left in src/ (the token itself); `var(--ease-spring)` present in the inlined critical CSS
- `@supports not (container-type)` block present; zero `@container (width >= …)` blocks in the output
- Cord SSRs as `class="pull-container"` (hidden) and gains `pull-container--ready` after idle hydration (DOM dump); the `--ready` rule ships in the async sheet
- Shared icon present in both island bundles; `addListener` fallback in the shipped JS
- /posts and homepage renders pixel-equivalent at 1280px (reduced-motion screenshots)
- `tsc` clean

Still open, intentionally: the shared drag hook (DraggableCard/BoardCard fork — bigger refactor, own PR) and the font-preload trio decision (needs a PSI measurement, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)